### PR TITLE
chore(claude): set up Claude Code rules and hooks

### DIFF
--- a/.claude/commands/commit-message.md
+++ b/.claude/commands/commit-message.md
@@ -1,0 +1,174 @@
+---
+allowed-tools: Bash(git status:*), Bash(git diff:*)
+description: Generate Conventional Commits message based on staged changes (Chinese & English versions)
+---
+
+## Task
+
+Analyze staged Git changes and generate commit messages. Do **not** execute `git commit`, `git add`, or any other mutating command under any circumstances — only output the message for the user to copy.
+
+## Git Status
+
+!git status --short
+
+## Staged Changes (primary analysis source)
+
+!git diff --cached
+
+## Unstaged Changes (for reference only — do not base commit message on these)
+
+!git diff
+
+## Commit Message Format
+
+Use Conventional Commits specification:
+
+```text
+<type>[(<scope>)][!]: <subject>
+
+<body>
+
+<footer>
+```
+
+### Type Selection Guide
+
+| Type       | Usage                                        | SemVer |
+| ---------- | -------------------------------------------- | ------ |
+| `feat`     | New feature or API                           | MINOR  |
+| `fix`      | Bug fix or error handling                    | PATCH  |
+| `perf`     | Performance improvement (no behavior change) | PATCH  |
+| `refactor` | Code restructuring (not feat / fix)          | —      |
+| `style`    | Formatting, whitespace, linting              | —      |
+| `docs`     | Documentation or comments only               | —      |
+| `test`     | Adding or modifying tests                    | —      |
+| `build`    | Build system or dependency changes           | —      |
+| `ci`       | CI/CD configuration changes                  | —      |
+| `chore`    | Other maintenance not affecting src/test     | —      |
+| `revert`   | Reverting a previous commit                  | —      |
+
+### Scope
+
+Infer from file paths or functional modules, e.g.: `auth`, `api`, `ui`, `components`, `utils`, `router`
+
+### Breaking Change
+
+Add `!` after type/scope; add `BREAKING CHANGE:` in footer:
+
+```text
+feat(button)!: remove size prop, use class instead
+
+BREAKING CHANGE: `size` prop has been removed. Use Tailwind classes directly via `class` attribute.
+```
+
+### Writing Guidelines
+
+- **Header** (`type(scope): subject`): ≤ 72 characters (ideally ≤ 50), no period at end
+- **subject**: Imperative mood — EN: lowercase start / ZH: 繁體中文，25 字以內
+- **body**: Explain **why**, not what. Bullet points for multi-item changes. Each line ≤ 72 characters
+- **footer**: Issue refs (`Closes #123`, `Refs #456`) or `BREAKING CHANGE:`
+
+---
+
+## Execution Steps
+
+1. **Check staged changes**
+   - If nothing staged → ask the user to stage the intended files first; do not proceed
+   - If changes exist but nothing staged → list the relevant unstaged paths and ask the user to stage them first; do not stage files yourself
+
+2. **Use this file as the source of truth**
+   - Follow the Conventional Commits rules below even if previous commits used a different format
+
+3. **Analyze staged diff** → determine type, infer scope, draft subject and body
+
+4. **Handle multiple unrelated changes** — if staged changes span unrelated concerns, output a concrete split plan **before** the commit messages:
+   ```
+   建議拆分為：
+   1. paths:
+      - apps/frontend/src/app/components/atoms/button/button.tsx
+      suggested message: feat(button): add loading state
+
+   2. paths:
+      - apps/frontend/docs/button.md
+      suggested message: docs(button): document loading prop
+   ```
+   Then still output a combined message as fallback.
+
+---
+
+## Output Format
+
+📝 **繁體中文版本 (Traditional Chinese)**
+
+```text
+<type>(<scope>): <中文 subject>
+
+<中文 body>
+
+<footer>
+```
+
+📝 **English Version**
+
+```text
+<type>(<scope>): <English subject>
+
+<English body>
+
+<footer>
+```
+
+---
+
+## Examples
+
+### Single-scope commit
+
+📝 **繁體中文版本**
+
+```text
+feat(auth): 新增第三方 OAuth 登入功能
+
+- 實作 Google / GitHub OAuth 登入流程
+- 新增 token 刷新機制
+- 將登入狀態同步至 store
+```
+
+📝 **English Version**
+
+```text
+feat(auth): add third-party OAuth login
+
+- Implement Google / GitHub OAuth login flow
+- Add token refresh mechanism
+- Sync login state to store
+```
+
+### Mixed changes → split plan
+
+> ⚠️ Staged changes contain unrelated modifications. Suggested split:
+>
+> ```
+> 1. paths:
+>    - apps/frontend/src/app/lib/api.ts
+>    - apps/frontend/src/app/types/product.ts
+>    suggested message: fix(api): handle product submission errors
+>
+> 2. paths:
+>    - apps/frontend/src/app/components/molecules/inventoryList/inventoryTableContent.tsx
+>    - apps/frontend/src/app/components/atoms/button/button.tsx
+>    suggested message: style(ui): adjust inventory table actions
+> ```
+
+(Combined fallback message follows below)
+
+---
+
+## Rules
+
+- Output both versions directly — do not ask for confirmation
+- **Never execute `git commit`** — only generate the message text
+- **Never execute mutating Git commands** such as `git add`, `git commit`, `git reset`, or `git checkout`
+- Ensure both versions carry consistent meaning
+- Accurately reflect staged changes only
+- If changes should be split, output the split plan **before** the commit messages

--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -1,0 +1,36 @@
+# Claude Hooks
+
+這個目錄放 Claude Code 與提交流程使用的小型 hook script。目標是把 POS 專案規則放在工作流旁邊提醒，但不把 hook 做成另一套複雜框架。
+
+## `check-context.sh`
+
+Claude `UserPromptSubmit` hook 會呼叫這支 script。它會讀取目前 Git 變更，依檔案路徑輸出對應提醒，例如：
+
+- Next.js / React / TypeScript 檔案：提醒 props、client boundary、hooks、type-check。
+- frontend components：提醒 Atomic Design、`cn()`、Tailwind semantic tokens。
+- backend Go / migration 檔案：提醒 handler/repository/DTO 邊界、migration pairing、Go tests。
+- `.claude`、docs、rules：提醒維持規則可審查、不要留下模板殘留。
+
+這支 script 只提供 context，不阻擋 Claude 或開發流程。它在 [.claude/settings.json](../settings.json) 中透過 `UserPromptSubmit` 掛載。
+
+## `pre-commit-validation.sh`
+
+這支 script 是提交前的風險對應驗證 helper。它只看 staged files，依變更類型跑必要檢查：
+
+- frontend JS/TS/TSX/config：`pnpm --filter frontend run type-check`
+- staged frontend JS/TS/TSX：`pnpm --filter frontend run lint-staged`
+- backend Go / SQL / module files：`cd apps/backend && go test ./...`
+- migration SQL：檢查 `.up.sql` / `.down.sql` 是否成對
+- shell script：`bash -n`
+- JSON：用 Node.js parse 檢查語法
+
+檢查失敗時會回傳非 0 exit code，可用於阻擋 commit。若目前沒有 staged files，會直接略過。
+
+## 手動執行
+
+```bash
+bash .claude/hooks/check-context.sh
+bash .claude/hooks/pre-commit-validation.sh
+```
+
+`check-context.sh` 是提醒工具；`pre-commit-validation.sh` 是驗證工具。兩者都應保持小而直接，新增檢查前先確認它解決真實問題。

--- a/.claude/hooks/check-context.sh
+++ b/.claude/hooks/check-context.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# Claude Code Hook: POS project context reminder
+# Trigger: UserPromptSubmit
+# Purpose: Print lightweight POS guidance based on changed files. This hook never blocks work.
+
+set -euo pipefail
+
+cd "${CLAUDE_PROJECT_DIR:-$(pwd)}" || exit 0
+
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+  exit 0
+fi
+
+changed_files="$(
+  {
+    git diff --name-only HEAD 2>/dev/null || true
+    git ls-files --others --exclude-standard 2>/dev/null || true
+  } | sort -u
+)"
+
+new_files="$(
+  {
+    git diff --name-only --diff-filter=A HEAD 2>/dev/null || true
+    git ls-files --others --exclude-standard 2>/dev/null || true
+  } | sort -u
+)"
+
+reminders=()
+
+has_changed() {
+  printf "%s\n" "$changed_files" | grep -Eq "$1"
+}
+
+has_new() {
+  printf "%s\n" "$new_files" | grep -Eq "$1"
+}
+
+reminders+=("[Claude]")
+reminders+=("- MUST check whether there are relevant skills to use first.")
+reminders+=("- State the problem in one sentence before changing code.")
+reminders+=("- Pick the smallest logical change that solves the real issue.")
+reminders+=("- Decide what evidence will prove the change works.")
+
+if [ -z "$changed_files" ]; then
+  reminders+=("")
+  reminders+=("[No Changed Files]")
+  reminders+=("- Keep the next change small and tied to POS project rules.")
+fi
+
+if has_changed '^apps/frontend/(src/.*\.(ts|tsx)|next\.config\.ts|tsconfig\.json|package\.json|components\.json|tailwind\.config\.ts|postcss\.config\.mjs|\.eslintrc\.json)$'; then
+  reminders+=("")
+  reminders+=("[Next.js / React / TypeScript]")
+  reminders+=("- Keep props and public interfaces explicit; avoid any.")
+  reminders+=("- Keep 'use client' at the smallest event, hook, or browser API boundary.")
+  reminders+=("- Check hooks dependencies, cleanup, and derived state.")
+  reminders+=("- Verification: pnpm --filter frontend run type-check; add lint/build when risk warrants.")
+  reminders+=("- Reference: .claude/rules/01-component-standards.md and .claude/rules/typescript.md")
+fi
+
+if has_changed '^apps/frontend/src/app/components/.*\.tsx$'; then
+  reminders+=("")
+  reminders+=("[Atomic Components]")
+  reminders+=("- Use .claude/skills/atomic-design-convention/SKILL.md when placing or changing components.")
+  reminders+=("- Choose atoms, molecules, organisms, templates, or pages by responsibility and reuse.")
+  reminders+=("- Merge classes with cn(), prefer semantic Tailwind tokens, and keep composition styles predictable.")
+  reminders+=("- Reference: .claude/rules/01-component-standards.md and .claude/rules/08-styling.md")
+fi
+
+if has_new '^apps/frontend/src/app/components/.*\.tsx$'; then
+  reminders+=("")
+  reminders+=("[New React Component]")
+  reminders+=("- Export shared components from the correct layer index when they are reusable.")
+  reminders+=("- Keep component filenames camelCase and component symbols PascalCase.")
+  reminders+=("- Make loading, empty, error, and responsive states explicit when user-facing.")
+fi
+
+if has_changed '^apps/frontend/src/app/hooks/.*\.(ts|tsx)$'; then
+  reminders+=("")
+  reminders+=("[React Hooks]")
+  reminders+=("- Effects synchronize with external systems; do not store values that can be derived.")
+  reminders+=("- Include complete dependencies and clean up timers, listeners, subscriptions, and object URLs.")
+  reminders+=("- Keep hook return shapes narrow and named by domain intent.")
+  reminders+=("- Reference: .claude/rules/01-component-standards.md and .claude/rules/05-state-error-handling.md")
+fi
+
+if has_changed '^apps/frontend/src/app/(lib|types)/.*\.ts$|^apps/frontend/src/app/.*/page\.tsx$|^apps/frontend/src/app/.*/layout\.tsx$'; then
+  reminders+=("")
+  reminders+=("[Data Boundaries / API Contracts]")
+  reminders+=("- Keep DTOs, helpers, and UI types aligned with real API shapes.")
+  reminders+=("- Treat external data as unknown at runtime, then narrow through small checks or adapters.")
+  reminders+=("- Do not leak repository, handler, temporary, or raw API shapes across boundaries.")
+  reminders+=("- Reference: .claude/rules/02-code-quality.md, .claude/rules/04-frontend-security.md, and .claude/rules/06-collaboration.md")
+fi
+
+if has_changed '^apps/frontend/(src/.*\.css|tailwind\.config\.ts|components\.json)$'; then
+  reminders+=("")
+  reminders+=("[Styling / Theme]")
+  reminders+=("- Use semantic design tokens; avoid scattered raw colors and one-off arbitrary styles.")
+  reminders+=("- Let tokens carry dark mode instead of branching each component's palette.")
+  reminders+=("- Keep component styling in className unless CSS is truly global or selector-driven.")
+  reminders+=("- Reference: .claude/rules/08-styling.md and .claude/rules/07-ui-reliability.md")
+fi
+
+if has_changed '^apps/backend/.*\.(go|sql)$|^apps/backend/go\.(mod|sum)$'; then
+  reminders+=("")
+  reminders+=("[Go Backend]")
+  reminders+=("- Keep handler, DTO, repository, and storage responsibilities separate.")
+  reminders+=("- Validate request data at trust boundaries and preserve database invariants.")
+  reminders+=("- Verification: cd apps/backend && go test ./...")
+  reminders+=("- Reference: .claude/rules/02-code-quality.md and .claude/rules/06-collaboration.md")
+fi
+
+if has_changed '^apps/backend/internal/storage/sql/migration/scripts/.*\.(up|down)\.sql$'; then
+  reminders+=("")
+  reminders+=("[SQL Migrations]")
+  reminders+=("- Keep migration up/down files paired and review data-loss risks directly.")
+  reminders+=("- Keep schema changes small enough to review and roll back.")
+fi
+
+if has_changed '^(\.claude/|AGENTS\.md$|apps/frontend/CLAUDE\.md$|.*\.md$)'; then
+  reminders+=("")
+  reminders+=("[Project Rules / Docs]")
+  reminders+=("- Keep rules tied to actual POS project behavior, not template leftovers.")
+  reminders+=("- Keep automation lightweight, reviewable, and honest about what it can block.")
+  reminders+=("- PR or handoff notes should explain problem, solution, verification, and remaining risk.")
+  reminders+=("- Reference: AGENTS.md and .claude/rules/README.md")
+fi
+
+large_components=()
+while IFS= read -r file; do
+  if [ -f "$file" ] && printf "%s\n" "$file" | grep -Eq '^apps/frontend/src/app/components/.*\.tsx$'; then
+    line_count="$(wc -l <"$file" 2>/dev/null || echo "0")"
+    if [ "$line_count" -gt 200 ]; then
+      large_components+=("$file ($line_count lines)")
+    fi
+  fi
+done <<< "$changed_files"
+
+if [ "${#large_components[@]}" -gt 0 ]; then
+  reminders+=("")
+  reminders+=("[Large React Components]")
+  reminders+=("- These component files exceed 200 lines; split only when responsibility is unclear:")
+  for component in "${large_components[@]}"; do
+    reminders+=("  - $component")
+  done
+fi
+
+if [ "${#reminders[@]}" -gt 0 ]; then
+  printf "\n"
+  printf "============================================================\n"
+  printf "  POS Project Context Reminder\n"
+  printf "============================================================\n"
+  for reminder in "${reminders[@]}"; do
+    printf "%s\n" "$reminder"
+  done
+  printf "============================================================\n"
+  printf "\n"
+fi
+
+exit 0

--- a/.claude/hooks/pre-commit-validation.sh
+++ b/.claude/hooks/pre-commit-validation.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# Optional Git/Husky pre-commit validation for the POS workspace.
+# This helper is risk-based: it runs only the checks implied by staged files.
+
+set -uo pipefail
+
+project_dir="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+cd "$project_dir" || exit 0
+
+echo "[pre-commit] Running POS validation..."
+
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+  echo "[pre-commit] Not in a git repository; skipping."
+  exit 0
+fi
+
+staged_files="$(git diff --cached --name-only --diff-filter=ACMR)"
+
+if [ -z "$staged_files" ]; then
+  echo "[pre-commit] No staged files."
+  exit 0
+fi
+
+echo "[pre-commit] Staged files:"
+printf "%s\n" "$staged_files" | sed 's/^/  - /'
+
+error_count=0
+
+has_staged() {
+  printf "%s\n" "$staged_files" | grep -Eq "$1"
+}
+
+increment_error() {
+  error_count=$((error_count + 1))
+}
+
+frontend_typecheck_pattern='^(apps/frontend/(src/.*\.(js|jsx|ts|tsx)|next\.config\.ts|tsconfig\.json|package\.json|components\.json|tailwind\.config\.ts|postcss\.config\.mjs|\.eslintrc\.json)|package\.json|pnpm-lock\.yaml|pnpm-workspace\.yaml)$'
+frontend_lint_staged_pattern='^apps/frontend/.*\.(js|jsx|ts|tsx)$'
+backend_pattern='^apps/backend/.*\.(go|sql)$|^apps/backend/go\.(mod|sum)$'
+
+if has_staged "$frontend_typecheck_pattern"; then
+  if command -v pnpm >/dev/null 2>&1; then
+    if pnpm --filter frontend run type-check; then
+      echo "[pre-commit] Frontend type check passed."
+    else
+      echo "[pre-commit] Frontend type check failed: pnpm --filter frontend run type-check"
+      increment_error
+    fi
+  else
+    echo "[pre-commit] pnpm not found; install pnpm to validate frontend changes."
+    increment_error
+  fi
+fi
+
+if has_staged "$frontend_lint_staged_pattern"; then
+  if command -v pnpm >/dev/null 2>&1; then
+    if pnpm --filter frontend run lint-staged; then
+      echo "[pre-commit] Frontend lint-staged passed."
+    else
+      echo "[pre-commit] Frontend lint-staged failed: pnpm --filter frontend run lint-staged"
+      increment_error
+    fi
+  else
+    echo "[pre-commit] pnpm not found; install pnpm to validate staged frontend files."
+    increment_error
+  fi
+fi
+
+if has_staged "$backend_pattern"; then
+  if command -v go >/dev/null 2>&1; then
+    if (cd apps/backend && go test ./...); then
+      echo "[pre-commit] Backend Go tests passed."
+    else
+      echo "[pre-commit] Backend Go tests failed: cd apps/backend && go test ./..."
+      increment_error
+    fi
+  else
+    echo "[pre-commit] go not found; install Go to validate backend changes."
+    increment_error
+  fi
+fi
+
+migration_files="$(printf "%s\n" "$staged_files" | grep -E '^apps/backend/internal/storage/sql/migration/scripts/.*\.(up|down)\.sql$' || true)"
+if [ -n "$migration_files" ]; then
+  while IFS= read -r file; do
+    [ -z "$file" ] && continue
+
+    case "$file" in
+      *.up.sql) pair="${file%.up.sql}.down.sql" ;;
+      *.down.sql) pair="${file%.down.sql}.up.sql" ;;
+      *) pair="" ;;
+    esac
+
+    if [ -n "$pair" ] && [ ! -f "$pair" ] && ! printf "%s\n" "$staged_files" | grep -Fxq "$pair"; then
+      echo "[pre-commit] Missing paired migration for $file: expected $pair"
+      increment_error
+    fi
+  done <<< "$migration_files"
+fi
+
+shell_files="$(printf "%s\n" "$staged_files" | grep -E '\.sh$' || true)"
+if [ -n "$shell_files" ]; then
+  while IFS= read -r file; do
+    [ -z "$file" ] && continue
+    [ -f "$file" ] || continue
+
+    if bash -n "$file"; then
+      echo "[pre-commit] Shell syntax passed: $file"
+    else
+      echo "[pre-commit] Shell syntax failed: $file"
+      increment_error
+    fi
+  done <<< "$shell_files"
+fi
+
+json_files="$(printf "%s\n" "$staged_files" | grep -E '\.json$' || true)"
+if [ -n "$json_files" ]; then
+  if command -v node >/dev/null 2>&1; then
+    while IFS= read -r file; do
+      [ -z "$file" ] && continue
+      [ -f "$file" ] || continue
+
+      if node -e "JSON.parse(require('fs').readFileSync(process.argv[1], 'utf8'))" "$file"; then
+        echo "[pre-commit] JSON syntax passed: $file"
+      else
+        echo "[pre-commit] JSON syntax failed: $file"
+        increment_error
+      fi
+    done <<< "$json_files"
+  else
+    echo "[pre-commit] node not found; install Node.js to validate staged JSON files."
+    increment_error
+  fi
+fi
+
+large_components=()
+tsx_component_files="$(printf "%s\n" "$staged_files" | grep -E '^apps/frontend/src/app/components/.*\.tsx$' || true)"
+if [ -n "$tsx_component_files" ]; then
+  while IFS= read -r file; do
+    [ -z "$file" ] && continue
+    [ -f "$file" ] || continue
+
+    line_count="$(wc -l <"$file" 2>/dev/null || echo "0")"
+    if [ "$line_count" -gt 200 ]; then
+      large_components+=("$file ($line_count lines)")
+    fi
+  done <<< "$tsx_component_files"
+fi
+
+if [ "${#large_components[@]}" -gt 0 ]; then
+  echo "[pre-commit] Warning: these React component files exceed 200 lines:"
+  for component in "${large_components[@]}"; do
+    echo "  - $component"
+  done
+fi
+
+if [ "$error_count" -gt 0 ]; then
+  echo "[pre-commit] Validation failed with $error_count error(s)."
+  exit 1
+fi
+
+echo "[pre-commit] Validation passed."
+exit 0

--- a/.claude/rules/01-component-standards.md
+++ b/.claude/rules/01-component-standards.md
@@ -1,0 +1,424 @@
+---
+paths:
+  [
+    'apps/frontend/src/**/*.tsx',
+    'apps/frontend/src/**/*.ts',
+    'apps/frontend/src/app/hooks/**/*.ts',
+  ]
+---
+
+# 組件生命週期與規範 / Component Lifecycle & Standards (準則 1-7)
+
+本文檔涵蓋 React 組件、Custom Hook、Next.js App Router 邊界與公開 API 的基本規範。
+
+This document covers React components, custom hooks, Next.js App Router boundaries, and public API standards.
+
+---
+
+## 準則 1: Props 類型定義 / Guideline 1: Props Type Definition
+
+### 說明 / Description
+
+Props 是組件的資料邊界。所有 component props 必須使用明確的 TypeScript interface，不使用 `any` 或隱含形狀。
+
+Props are component data boundaries. All component props must use explicit TypeScript interfaces, with no `any` or implicit shapes.
+
+### 為什麼重要 / Why This Matters
+
+清楚的 props interface 讓工程師與 Claude Code 都能直接判斷組件輸入、預設值與重構影響。
+
+### Linus 哲學 / Linus Philosophy
+
+> "Bad programmers worry about the code. Good programmers worry about data structures."
+
+Design the data structure well first, and special cases will naturally disappear.
+
+### 檢查清單 / Checklist
+
+- [ ] Props 是否使用 `interface ComponentNameProps`？
+- [ ] 是否避免 `any`、`@ts-ignore`？
+- [ ] 選填 props 是否使用 `?`，並在需要具體值時提供預設值？
+- [ ] 複雜或共用型別是否放在 `@/app/types/`？
+- [ ] Props 超過 7 個時，是否重新檢查資料結構或責任邊界？
+
+### 範例 / Examples
+
+```tsx
+interface ProductCardProps {
+  product: Product
+  isSelected?: boolean
+  onSelect?: (id: string) => void
+}
+
+export function ProductCard({
+  product,
+  isSelected = false,
+  onSelect,
+}: ProductCardProps) {
+  return (
+    <button type="button" onClick={() => onSelect?.(product.id)}>
+      {product.name}
+    </button>
+  )
+}
+```
+
+### 常見陷阱 / Common Pitfalls
+
+- 用 `any` 快速繞過型別問題。
+- props 過多時只分組表面欄位，沒有真正整理 domain model。
+
+### 參考現有實作 / Reference Implementation
+
+- `apps/frontend/src/app/components/molecules/common/genericConfirmDialog.tsx`
+
+### 自動化 / Automation
+
+- **TypeScript**: `pnpm --filter frontend run type-check`
+- **ESLint**: `@typescript-eslint/no-explicit-any`
+
+---
+
+## 準則 2: Callback Props 規範 / Guideline 2: Callback Props
+
+### 說明 / Description
+
+子組件通知父層時使用 callback props，命名為 `onXxx`。Callback 是組件的輸出事件，不應藏在 event bus 或不透明的全域狀態中。
+
+Use callback props named `onXxx` for child-to-parent communication. Callbacks are component output events and should not be hidden in event buses or opaque global state.
+
+### 為什麼重要 / Why This Matters
+
+事件出口放在 props 上，行為邊界清楚，也比較容易測試與替換。
+
+### Linus 哲學 / Linus Philosophy
+
+> "Good code has no special cases."
+
+Data flows in, events flow out. Do not create hidden paths.
+
+### 檢查清單 / Checklist
+
+- [ ] 對外事件是否命名為 `onXxx`？
+- [ ] 選填 callback 是否使用 optional chaining？
+- [ ] 必要 callback 是否直接標為必填？
+- [ ] 子組件是否避免直接擁有 API mutation，除非它就是 feature boundary？
+- [ ] callback 是否只在 Client Component 子樹內作為一般函數傳遞？
+
+### 範例 / Examples
+
+```tsx
+interface DeleteButtonProps {
+  onDelete: () => void
+  isDeleting?: boolean
+}
+
+export function DeleteButton({
+  onDelete,
+  isDeleting = false,
+}: DeleteButtonProps) {
+  return (
+    <button onClick={onDelete} disabled={isDeleting}>
+      刪除
+    </button>
+  )
+}
+```
+
+### 常見陷阱 / Common Pitfalls
+
+- 把必要 callback 寫成 optional，最後到處補防守邏輯。
+- 子組件直接呼叫 API，導致 UI primitive 變成 feature 邏輯。
+
+### 參考現有實作 / Reference Implementation
+
+- `apps/frontend/src/app/layout.tsx` - 保持 layout 輕薄，將互動行為交給明確的 client 子元件。
+- `apps/frontend/src/app/product/add-product/page.tsx` - 頁面目前需要表單 state 與 event handler，因此明確標示 `'use client'`。
+
+### 自動化 / Automation
+
+- **TypeScript**: callback 參數與回傳型別檢查。
+
+---
+
+## 準則 3: Custom Hook 與副作用 / Guideline 3: Custom Hooks And Effects
+
+### 說明 / Description
+
+只有當狀態邏輯可重用，或組件已難以閱讀時，才抽出 custom hook。副作用必須有完整依賴與必要 cleanup。
+
+Extract custom hooks only when stateful logic is reusable or the component has become hard to read. Effects must have complete dependencies and required cleanup.
+
+### 為什麼重要 / Why This Matters
+
+Hook 應降低複雜度，不是把複雜度搬到另一個檔案。副作用沒有 cleanup 會留下 leak 與不穩定行為。
+
+### Linus 哲學 / Linus Philosophy
+
+> "Functions must be short and sharp, doing just one thing well."
+
+Good boundaries reduce problems, not just file length.
+
+### 檢查清單 / Checklist
+
+- [ ] Hook 是否以 `use` 開頭？
+- [ ] 抽 hook 是否真的降低認知負擔？
+- [ ] `useEffect` dependency 是否完整？
+- [ ] 是否清理 timer、listener、subscription、object URL 或 abortable async work？
+- [ ] 是否避免在 render 或 initial state 讀取 `window`、`document`？
+
+### 範例 / Examples
+
+```tsx
+type WindowSize = {
+  width: number
+  height: number
+}
+
+export function useWindowSize(): WindowSize {
+  const [size, setSize] = useState<WindowSize>({ width: 0, height: 0 })
+
+  useEffect(() => {
+    const handleResize = () => {
+      setSize({ width: window.innerWidth, height: window.innerHeight })
+    }
+
+    handleResize()
+    window.addEventListener('resize', handleResize)
+    return () => window.removeEventListener('resize', handleResize)
+  }, [])
+
+  return size
+}
+```
+
+### 常見陷阱 / Common Pitfalls
+
+- 為了低於 200 行而抽 hook，但呼叫端仍需要理解所有內部細節。
+- 建立 `URL.createObjectURL()` 後沒有 `URL.revokeObjectURL()`。
+
+### 參考現有實作 / Reference Implementation
+
+- `apps/frontend/src/app/components/molecules/addProduct/imagePreview.tsx`
+
+### 自動化 / Automation
+
+- **ESLint**: `react-hooks/rules-of-hooks`
+- **ESLint**: `react-hooks/exhaustive-deps`
+
+---
+
+## 準則 4: Next.js Client Boundary / Guideline 4: Next.js Client Boundary
+
+### 說明 / Description
+
+目前專案多數頁面以 Client Component / CSR 操作體驗為主，不以 SSR 作為主要策略。新增或重構 App Router 頁面時，應清楚標示需要 client runtime 的邊界，不要把 SSR、Server Action 或 Route Handler 當成預設解法。
+
+Most current pages are Client Components and the project is not SSR-first. New or refactored App Router pages should make client runtime boundaries explicit and avoid treating SSR, Server Actions, or Route Handlers as defaults.
+
+### 為什麼重要 / Why This Matters
+
+Client boundary 越清楚，bundle、資料暴露與 hydration 風險越低。這條規則是防止 runtime 邊界混亂，不是要求頁面改成 SSR。
+
+### Linus 哲學 / Linus Philosophy
+
+> "Good code has no special cases."
+
+Do not use SSR or page-wide client boundaries to hide data and interaction boundaries.
+
+### 檢查清單 / Checklist
+
+- [ ] `page.tsx` / `layout.tsx` 是否維持簡單，沒有把 SSR/RSC 當成預設資料策略？
+- [ ] `'use client'` 是否只加在需要 state、event、effect、browser API 的最小元件？
+- [ ] Client Component 是否避免 `async function`？
+- [ ] 跨 runtime 邊界的 props 是否可序列化？
+- [ ] 是否避免跨邊界傳一般函數、`Date`、`Map`、`Set`、class instance？
+
+### 範例 / Examples
+
+```tsx
+export default function ProductPage() {
+  return <ProductTableClient />
+}
+```
+
+### 常見陷阱 / Common Pitfalls
+
+- 跨 runtime 邊界傳一般 callback。
+- 直接把 `Date` 傳給 Client Component，應先轉成 ISO string。
+
+### 參考現有實作 / Reference Implementation
+
+- `apps/frontend/src/app/components/molecules/addProduct/imagePreview.tsx`
+
+### 自動化 / Automation
+
+- **Next.js**: lint/build 可揭露部分 Client Component 與 hydration 邊界問題。
+
+---
+
+## 準則 5: Import 與公開 API / Guideline 5: Imports And Public API
+
+### 說明 / Description
+
+使用穩定、清楚的 import 路徑。Barrel export 可以作為 layer 的公開 API，但不應暴露 helper 或不穩定實作。
+
+Use stable and clear import paths. Barrel exports may define a layer public API, but should not expose helpers or unstable internals.
+
+### 為什麼重要 / Why This Matters
+
+公開 API 一旦被使用就會變成承諾；不要讓內部結構變成外部依賴。
+
+### Linus 哲學 / Linus Philosophy
+
+> "Never break userspace."
+
+Do not accidentally commit to internal implementation details.
+
+### 檢查清單 / Checklist
+
+- [ ] 是否避免 `../../../components/...` 這類深層相對 import？
+- [ ] 是否優先使用 `@/app/...` alias？
+- [ ] `index.ts` / `index.tsx` 是否只 export 公開 API？
+- [ ] 是否避免新增無差別 `export *`？
+- [ ] Client Component 經 barrel export 時是否確認邊界合理？
+
+### 範例 / Examples
+
+```tsx
+import { Button } from '@/app/components/atoms'
+```
+
+```ts
+export { Button } from './button/button'
+export { Input } from './input'
+```
+
+### 常見陷阱 / Common Pitfalls
+
+- 為了方便新增 `export *`，讓 public surface 失控。
+- 把內部 helper 從 layer barrel 暴露出去。
+
+### 參考現有實作 / Reference Implementation
+
+- `apps/frontend/src/app/components/atoms/index.tsx`
+
+### 自動化 / Automation
+
+- **TypeScript**: path alias 解析。
+
+---
+
+## 準則 6: 組件大小與拆分 / Guideline 6: Component Size And Splitting
+
+### 說明 / Description
+
+單個 `.tsx` component file 應控制在 200 行以內。超過 200 行是 review trigger，不是強迫拆出假抽象的理由。
+
+A single `.tsx` component file should stay under 200 lines. Exceeding 200 lines is a review trigger, not a reason to create fake abstractions.
+
+### 為什麼重要 / Why This Matters
+
+小檔案只有在責任邊界清楚時才有價值。拆分應改善資料流、狀態邊界或可讀性。
+
+### Linus 哲學 / Linus Philosophy
+
+> "Functions must be short and sharp, doing just one thing well."
+
+Conciseness is not a line-count game; what you are really eliminating are error boundaries and special cases.
+
+### 檢查清單 / Checklist
+
+- [ ] `.tsx` component file 是否低於 200 行？
+- [ ] 超過時是否先檢查資料、狀態與 UI 責任是否混在一起？
+- [ ] 是否優先抽出資料/狀態邏輯，再拆 JSX？
+- [ ] 新抽出的 component 或 hook 是否有清楚 interface？
+- [ ] 是否避免只為了藏行數而拆檔？
+
+### 範例 / Examples
+
+```tsx
+function InventoryPage() {
+  const inventory = useInventoryList()
+
+  return (
+    <>
+      <InventoryTableHeader filters={inventory.filters} />
+      <InventoryTableContent data={inventory.data} />
+    </>
+  )
+}
+```
+
+### 常見陷阱 / Common Pitfalls
+
+- 只把 JSX 搬到另一個檔案，但資料流仍然纏在一起。
+- 抽出只使用一次且語意不清的 component。
+
+### 參考現有實作 / Reference Implementation
+
+- `apps/frontend/src/app/components/molecules/inventoryList/inventoryTableHeader.tsx`
+
+---
+
+## 準則 7: 檢查與格式化 / Guideline 7: Checks And Formatting
+
+### 說明 / Description
+
+完成前需執行與改動相關的 TypeScript、ESLint、Prettier 檢查。無法執行時必須明確回報。
+
+Run relevant TypeScript, ESLint, and Prettier checks before completion. Report clearly when a check cannot be run.
+
+### 為什麼重要 / Why This Matters
+
+工具能穩定檢查的事，不應交給人工記憶或主觀信心。
+
+### Linus 哲學 / Linus Philosophy
+
+> "Talk is cheap. Show me the code."
+
+Use tools for what can be automated; save review for design and behavior.
+
+### 檢查清單 / Checklist
+
+- [ ] 是否執行 `pnpm --filter frontend run type-check`？
+- [ ] 是否執行 `pnpm --filter frontend run lint`？
+- [ ] 若無法執行，是否在回報中說明原因？
+- [ ] 若升級 Next.js 16，是否將 lint 改為 ESLint CLI？
+
+### 範例 / Examples
+
+```bash
+pnpm --filter frontend run type-check
+pnpm --filter frontend run lint
+```
+
+### 常見陷阱 / Common Pitfalls
+
+- 只跑 format，卻宣稱型別與 hooks 規則沒問題。
+- 把無法執行的檢查當成通過。
+
+### 參考現有實作 / Reference Implementation
+
+- `apps/frontend/package.json`
+
+### 自動化 / Automation
+
+- **TypeScript**: `pnpm --filter frontend run type-check`
+- **ESLint**: `pnpm --filter frontend run lint`
+- **Git Hook**: Husky pre-commit 會執行 `type-check` 與 `lint-staged`
+- **lint-staged**: staged JS/TS 檔案會執行 `eslint --fix` 與 `prettier --write`
+
+---
+
+## 相關文檔 / Related Documents
+
+- [AGENTS.md](../../AGENTS.md) - Linus Torvalds 開發哲學
+- [README.md](README.md) - 準則總覽
+- [Next.js ESLint](https://nextjs.org/docs/app/api-reference/config/eslint) - Next.js ESLint 配置
+- [React Hooks Rules](https://react.dev/reference/rules/rules-of-hooks) - React 官方 Hooks 規則
+
+---
+
+**最後更新 / Last Updated**: 2026-05-16
+**維護者 / Maintainer**: POS Team

--- a/.claude/rules/02-code-quality.md
+++ b/.claude/rules/02-code-quality.md
@@ -1,0 +1,739 @@
+---
+paths:
+  [
+    'apps/frontend/src/**/*.tsx',
+    'apps/frontend/src/**/*.ts',
+    'apps/frontend/src/app/hooks/**/*.ts',
+    'apps/frontend/src/app/lib/**/*.ts',
+    'apps/frontend/src/app/types/**/*.ts',
+    'apps/backend/**/*.go',
+    'apps/backend/internal/storage/sql/migration/scripts/**/*.sql',
+  ]
+---
+
+# 程式碼品質 / Code Quality (準則 8-13)
+
+本文檔涵蓋 POS 專案的程式碼品質準則，目標是讓程式碼容易審查、容易修改，並且符合目前 Next.js 15、React 19、TypeScript、Tailwind CSS 與 Go/Gin backend 的實際架構。
+
+This document covers code quality guidelines for the POS project, keeping code reviewable, maintainable, and aligned with the current Next.js 15, React 19, TypeScript, Tailwind CSS, and Go/Gin backend stack.
+
+---
+
+## 準則 8: 資料邊界與封裝 / Guideline 8: Data Boundaries And Encapsulation
+
+### 說明 / Description
+
+資料邊界要清楚。Hook、component、helper 函式、handler、repository 與 DTO 只暴露呼叫端真正需要的資料與操作，不把內部狀態、setter、暫存資料格式或資料庫原始欄位外洩到不需要知道的地方。
+
+Data boundaries must be explicit. Hooks, components, utilities, handlers, repositories, and DTOs should expose only the data and operations their callers need, without leaking internal state, setters, temporary shapes, or raw database fields.
+
+### 為什麼重要 / Why This Matters
+
+- **易於審查**：介面小，審查者才能快速判斷影響範圍。
+- **降低耦合**：內部實作可以替換，不會牽動整個功能。
+- **資料流更安全**：敏感欄位、暫存狀態與僅供 UI 使用的格式不會意外流到錯的層。
+
+### Linus 哲學 / Linus Philosophy
+
+> "Bad programmers worry about the code. Good programmers worry about data structures."
+
+Define data boundaries first, then write the flow. Good data structures reduce special cases; bad boundaries pull every caller into internal details.
+
+### 檢查清單 / Checklist
+
+- [ ] Hook 回傳值是否只包含呼叫端需要的狀態與行為？
+- [ ] 是否避免把 `setState`、`dispatch` 或原始 mutable object 直接暴露出去？
+- [ ] API 回應或模擬資料是否轉成頁面實際使用的 DTO 或 View Model？
+- [ ] Backend handler 是否只處理 HTTP 輸入輸出，避免把 SQL 或資料庫細節推到 handler？
+- [ ] Repository 是否只回傳 model 或明確結果，不直接組裝前端顯示字串？
+- [ ] 顯示用字串與可計算資料是否分清楚，例如價格數值與顯示文字？
+- [ ] 錯誤訊息是否避免暴露 token、路徑、SQL、stack trace 或內部欄位？
+
+### 範例 / Examples
+
+**不推薦 ❌ - 把內部狀態整包丟出去**:
+
+```tsx
+export function useInventory() {
+  const [items, setItems] = useState<IInventoryItem[]>([])
+  const [selectedRows, setSelectedRows] = useState<Set<string>>(new Set())
+
+  return { items, setItems, selectedRows, setSelectedRows }
+}
+```
+
+**推薦 ✅ - 暴露業務操作與穩定介面**:
+
+```tsx
+interface InventoryListResult {
+  tableData: {
+    products: IProduct[]
+    selectedRows: Set<string>
+  }
+  actions: {
+    onSelectRow: (id: string, checked: boolean) => void
+    onDelete: (id: string) => void
+  }
+}
+
+export function useInventoryList(): InventoryListResult {
+  // Internal state stays here.
+  return { tableData, actions }
+}
+```
+
+**推薦 ✅ - 在邊界轉換成 View Model**:
+
+```ts
+export function toProductViewModel(item: IInventoryItem): IProduct {
+  const totalStock = calculateTotalStock(item)
+
+  return {
+    id: item.id,
+    name: item.name,
+    category: item.category,
+    specification: item.specifications.map((spec) => spec.name).join(', '),
+    specifications: item.specifications,
+    price: `NT$ ${item.price.toLocaleString()}`,
+    inventory: totalStock === 0 ? '缺貨' : `${totalStock} 件`,
+    totalStock,
+    image: item.image,
+  }
+}
+```
+
+**推薦 ✅ - Backend 在 DTO 邊界轉換回應格式**:
+
+```go
+func ToProductDetailResponse(p *model.ProductWithDetails) ProductDetailResponse {
+	resp := ToProductResponse(p)
+	return ProductDetailResponse(resp)
+}
+```
+
+### 常見陷阱 / Common Pitfalls
+
+**陷阱 1: 把 UI 暫存格式當成領域模型**
+
+```ts
+// ❌ quantity 在輸入框中是 string，卻直接存成庫存資料
+const productSpec = { name, quantity: quantityInput }
+
+// ✅ 儲存前明確轉換與驗證
+const quantity = Number.parseInt(quantityInput, 10)
+if (Number.isNaN(quantity) || quantity < 0) return
+const productSpec = { name, quantity }
+```
+
+**陷阱 2: 為了方便直接暴露 setter**
+
+```tsx
+// ❌ 呼叫端可以繞過驗證與副作用
+return { filters, setFilters }
+
+// ✅ 對外提供有語意的操作
+return { filters, updateFilters, resetFilters }
+```
+
+### 參考現有實作 / Reference Implementation
+
+專案中的參考範例：
+
+- `apps/frontend/src/app/hooks/inventory-list/useInventoryList.ts` - 將 table、pagination、filters、dialogs、actions 分組回傳。
+- `apps/frontend/src/app/lib/inventoryUtils.ts` - 將 inventory item 轉成 UI 需要的 Product View Model。
+- `apps/backend/internal/dto/product.go` - 將 backend model 轉成 API response。
+- `apps/backend/internal/repository/product.go` - 將 SQL 與 transaction 細節限制在 repository。
+
+### 自動化 / Automation
+
+- **TypeScript**: `pnpm --filter frontend run type-check`
+- **Go**: backend 變更後執行 `cd apps/backend && go test ./...`
+- **Git Hook**: Husky pre-commit 會執行 type-check 與 staged lint/format。
+
+---
+
+## 準則 9: 命名與語意 / Guideline 9: Naming And Semantics
+
+### 說明 / Description
+
+命名要說明資料的角色，而不是留下開發當下的暫時想法。共用、匯出或跨檔案使用的名稱必須清楚；區域暫存名稱可以短，但不能讓讀者猜。
+
+Names should describe the role of the data, not the developer's temporary thought process. Shared, exported, or cross-file names must be explicit; local names can be short only when their meaning is obvious.
+
+### 為什麼重要 / Why This Matters
+
+- **可讀性**：好的名稱讓程式碼自己說明意圖。
+- **審查更快**：審查者不需要在多個檔案間推理 `tmp`、`data`、`flag` 是什麼。
+- **重構更安全**：名稱與型別一致時，重構比較不容易改錯。
+
+### Linus 哲學 / Linus Philosophy
+
+If a name requires a comment to be understood, the name should usually be changed first. Comments should explain constraints and trade-offs, not clean up after poor naming choices.
+
+### 檢查清單 / Checklist
+
+- [ ] 布林值是否使用 `is`、`has`、`should`、`can` 前綴？
+- [ ] 陣列、集合與單一資料是否從名稱能分辨，例如 `products` vs `product`？
+- [ ] 是否避免 pinyin、無意義縮寫與 `tmp`、`data`、`obj` 這類跨多行仍不清楚的名稱？
+- [ ] 事件 handler 是否遵守 component 內部 `handleXxx`、props 對外 `onXxx`？
+- [ ] 常數是否用具名常數說明魔法數字或領域規則？
+
+### 範例 / Examples
+
+**不推薦 ❌ - 名稱需要讀者猜**:
+
+```ts
+const d = new Date()
+const flg = selectedRows.size > 0
+const tmp = products.filter((p) => p.inventory !== '缺貨')
+
+function proc(data: unknown) {
+  return data
+}
+```
+
+**推薦 ✅ - 名稱表達語意**:
+
+```ts
+const currentDate = new Date()
+const hasSelectedRows = selectedRows.size > 0
+const inStockProducts = products.filter((product) => product.totalStock > 0)
+
+function normalizeInventoryItem(item: IInventoryItem): IProduct {
+  return toProductViewModel(item)
+}
+```
+
+**推薦 ✅ - 事件命名分清楚輸入與輸出**:
+
+```tsx
+interface InventoryTableProps {
+  onDelete: (id: string) => void
+}
+
+function InventoryTable({ onDelete }: InventoryTableProps) {
+  const handleDeleteClick = (id: string) => {
+    onDelete(id)
+  }
+}
+```
+
+### 常見陷阱 / Common Pitfalls
+
+**陷阱 1: 型別與名稱不一致**
+
+```ts
+// ❌ 名稱看起來是單筆，實際是陣列
+const product = products.filter((item) => item.totalStock > 0)
+
+// ✅ 名稱反映資料結構
+const availableProducts = products.filter((item) => item.totalStock > 0)
+```
+
+**陷阱 2: 否定命名製造雙重否定**
+
+```ts
+// ❌ 難讀
+const isNotDisabled = false
+if (!isNotDisabled) return
+
+// ✅ 用肯定語意
+const isEnabled = true
+if (!isEnabled) return
+```
+
+### 參考現有實作 / Reference Implementation
+
+專案中的參考範例：
+
+- `apps/frontend/src/app/types/inventoryList.ts` - props interface 與 inventory 領域型別集中定義。
+- `apps/frontend/src/app/hooks/inventory-list/useInventoryPagination.ts` - pagination 狀態名稱直接對應 UI 使用方式。
+
+### 自動化 / Automation
+
+- **TypeScript**: 型別與 interface 可輔助發現名稱和資料結構不一致。
+- **Git Hook**: Husky pre-commit 不阻擋命名問題。
+
+---
+
+## 準則 10: 函數拆分與控制流 / Guideline 10: Function Splitting And Control Flow
+
+### 說明 / Description
+
+函數應短而直接。優先用資料結構、提前 return 與小 helper 函式降低巢狀，而不是把一段難懂邏輯壓縮成更難懂的一行。
+
+Functions should be short and direct. Prefer data structure choices, early returns, and small helpers to reduce nesting, instead of compressing hard logic into harder one-liners.
+
+### 為什麼重要 / Why This Matters
+
+- **降低認知負荷**：讀者能一次理解一個責任。
+- **更容易測試**：小函數比較容易用聚焦測試保護。
+- **行為更清楚**：淺層控制流讓錯誤路徑更明顯。
+
+### Linus 哲學 / Linus Philosophy
+
+> "If you need more than three levels of indentation, you're screwed and should fix your program."
+
+Deep nesting is usually not an indentation problem but a data flow or responsibility boundary problem. Flatten the main flow first, then decide whether to split functions.
+
+### 檢查清單 / Checklist
+
+- [ ] 函數是否能用一句話說明責任？
+- [ ] 巢狀是否維持在 3 層以內？
+- [ ] 是否能用提前 return 處理 invalid、loading、permission 等阻擋條件？
+- [ ] 是否避免把驗證、轉換、API 變更操作、UI state 全塞進同一個函數？
+- [ ] 拆出的 helper 函式是否有清楚名稱，而不是只為了降低行數？
+
+### 範例 / Examples
+
+**不推薦 ❌ - 主流程被阻擋條件包住**:
+
+```tsx
+async function handleSave() {
+  if (isValid) {
+    if (hasPermission) {
+      if (selectedProduct) {
+        await saveProduct(selectedProduct)
+        toast('已儲存')
+      }
+    }
+  }
+}
+```
+
+**推薦 ✅ - 提前 return 讓主流程在最外層**:
+
+```tsx
+async function handleSave() {
+  if (!isValid) return
+  if (!hasPermission) return
+  if (!selectedProduct) return
+
+  await saveProduct(selectedProduct)
+  toast('已儲存')
+}
+```
+
+**推薦 ✅ - 按責任拆分資料處理**:
+
+```ts
+export function buildProductRows(items: IInventoryItem[]): IProduct[] {
+  return items
+    .map(toProductViewModel)
+    .filter((product) => product.totalStock > 0)
+}
+```
+
+### 常見陷阱 / Common Pitfalls
+
+**陷阱 1: 為每兩行建立 helper 函式**
+
+```ts
+// ❌ 抽象沒有降低理解成本
+function addOne(value: number) {
+  return value + 1
+}
+
+// ✅ 簡單運算保持直接
+const nextPage = currentPage + 1
+```
+
+**陷阱 2: 用巢狀 callback 隱藏流程**
+
+```ts
+// ❌ 每層都改變上下文
+products.forEach((product) => {
+  product.specifications.forEach((spec) => {
+    if (spec.quantity > 0) {
+      rows.push({ product, spec })
+    }
+  })
+})
+
+// ✅ 用命名 helper 函式表達資料轉換
+const rows = products.flatMap(buildSpecificationRows)
+```
+
+### 參考現有實作 / Reference Implementation
+
+專案中的參考範例：
+
+- `apps/frontend/src/app/hooks/inventory-list/useInventoryPagination.ts` - 分頁計算集中在一個 hook，對外介面清楚。
+- `apps/frontend/src/app/hooks/inventory-list/useInventorySearch.ts` - 搜尋字串整理與 filter 流程放在同一個局部區塊。
+
+### 自動化 / Automation
+
+- **TypeScript**: `pnpm --filter frontend run type-check`
+- **Git Hook**: Husky pre-commit 不阻擋函數長度問題。
+
+---
+
+## 準則 11: 重構取捨與替代方案 / Guideline 11: Refactoring Trade-offs And Alternatives
+
+### 說明 / Description
+
+重構要服務當前問題。看到重複、特殊情況或難以審查的流程時，先找能刪掉分支或縮小邊界的替代做法；不要為了「看起來進階」新增模式、類別或依賴。
+
+Refactoring must serve the current problem. When duplication, special cases, or hard-to-review flow appears, compare alternatives that remove branches or shrink boundaries. Do not add patterns, classes, or dependencies just to look advanced.
+
+### 為什麼重要 / Why This Matters
+
+- **真正的可維護性**：重構應降低未來修改成本，不是換一種複雜。
+- **變更更小**：替代方案清楚時，PR 更容易審。
+- **更少邊界情況**：把特殊情況變成一般流程，出錯範圍自然變小。
+
+### Linus 哲學 / Linus Philosophy
+
+> "Sometimes you can look at a problem from a different angle, rewrite it so the special case disappears and becomes the normal case."
+
+Good taste is not about adding more abstraction — it is about making exceptions disappear. The best refactors usually delete code.
+
+### 檢查清單 / Checklist
+
+- [ ] 這次重構是否解決具體 bug、重複或維護成本？
+- [ ] 是否先比較 2 種以上可行做法，再選最小的一種？
+- [ ] 是否能用資料表、Map、查表或標準 API 消除分支？
+- [ ] 抽象是否已出現穩定重複，而不是第一次使用就抽？
+- [ ] PR 是否避免混入格式化、搬檔、功能與重構多種不相關改動？
+
+### 範例 / Examples
+
+**不推薦 ❌ - 用分支堆疊狀態規則**:
+
+```ts
+function getStockLabel(totalStock: number) {
+  if (totalStock === 0) return '缺貨'
+  if (totalStock > 0) return `${totalStock} 件`
+  return '未知'
+}
+```
+
+**推薦 ✅ - 先修資料不變式，讓特殊情況消失**:
+
+```ts
+function getStockLabel(totalStock: number) {
+  return totalStock === 0 ? '缺貨' : `${totalStock} 件`
+}
+```
+
+**推薦 ✅ - 穩定重複後才抽資料表**:
+
+```ts
+const STOCK_STATUS_LABEL: Record<IFilterState['stockStatus'], string> = {
+  all: '全部',
+  'in-stock': '有庫存',
+  'out-of-stock': '缺貨',
+}
+```
+
+### 常見陷阱 / Common Pitfalls
+
+**陷阱 1: 為單一使用情境建立策略模式**
+
+```ts
+// ❌ 目前只有 inventory 一種資料，卻先做多層 strategy
+interface ExportStrategy {
+  export(items: unknown[]): string
+}
+
+// ✅ 先寫目前需要的函數
+function exportInventoryItems(items: IInventoryItem[]): string {
+  return JSON.stringify(items)
+}
+```
+
+**陷阱 2: 重構 PR 偷渡行為變更**
+
+```ts
+// ❌ 名義上重構，實際也改了篩選語意
+const filtered = products.filter((product) => product.totalStock >= 0)
+
+// ✅ 重構只改結構，不改結果
+const filtered = products.filter(isProductVisible)
+```
+
+### 參考現有實作 / Reference Implementation
+
+專案中的參考範例：
+
+- `apps/frontend/src/app/lib/strategies/` - 當 category 行為已形成穩定差異時再集中策略。
+- `apps/frontend/src/app/hooks/inventory-list/` - 將 inventory list 的搜尋、分頁、選取、編輯與刪除拆成可審查的小單元。
+
+### 自動化 / Automation
+
+- **TypeScript**: 可保護重構後的型別契約。
+- **Git Hook**: Husky pre-commit 可攔截型別與 staged lint/format 問題。
+
+---
+
+## 準則 12: 框架正確性 / Guideline 12: Framework Correctness
+
+### 說明 / Description
+
+前端 Hooks 先求正確，再談優化；後端 handler、repository 與 migration 先守住資料不變式，再談抽象。`useEffect` 應用來同步外部系統，不應拿來搬運可由 props 或 state 直接推導的資料。Go handler 應處理 HTTP 驗證與回應，repository 應處理資料存取與 transaction，不互相偷責任。
+
+Frontend hooks should be correct before optimized; backend handlers, repositories, and migrations should protect data invariants before adding abstraction. `useEffect` should synchronize with external systems, not move data that can be derived from props or state. Go handlers should handle HTTP validation and responses; repositories should handle persistence and transactions.
+
+### 為什麼重要 / Why This Matters
+
+- **狀態可預期**：可由既有資料推導的值不另存 state，資料來源才單一。
+- **避免過期閉包**：完整 dependency 可避免讀到舊資料與難追的 bug。
+- **有效的效能調整**：memo 只用在測量後需要的地方，不製造額外心智負擔。
+- **後端邊界清楚**：HTTP、DTO、SQL 與 transaction 各守各的位置，問題才容易定位。
+
+### Linus 哲學 / Linus Philosophy
+
+Reliability comes from simple data flow. Every redundant state, missing dependency, unnecessary memo, or handler/repository shortcut that bleeds responsibilities is a special case that will need maintaining in the future.
+
+### 檢查清單 / Checklist
+
+- [ ] Hook 是否只在 React component 或 custom hook 的頂層呼叫？
+- [ ] `useEffect` dependency 是否完整？
+- [ ] timer、event listener、subscription、object URL、abortable async work 是否清理？
+- [ ] 可由現有資料計算的值是否避免放入 `useState`？
+- [ ] `useMemo` 或 `useCallback` 是否有實際目的，例如昂貴計算或 memoized child？
+- [ ] Handler 是否完成 request validation，並回傳統一的 DTO response？
+- [ ] Repository 是否使用 `context.Context`、parameterized query 與 transaction helper，而不是手組 SQL 字串？
+- [ ] Migration 是否有成對 up/down，且欄位預設值與現有資料相容？
+
+### 範例 / Examples
+
+**不推薦 ❌ - 用 Effect 同步可推導的 state**:
+
+```tsx
+const [items, setItems] = useState<IProduct[]>([])
+const [count, setCount] = useState(0)
+
+useEffect(() => {
+  setCount(items.length)
+}, [items])
+```
+
+**推薦 ✅ - 直接推導**:
+
+```tsx
+const [items, setItems] = useState<IProduct[]>([])
+const count = items.length
+const isEmpty = count === 0
+```
+
+**推薦 ✅ - Effect 連接外部系統並提供 cleanup**:
+
+```tsx
+useEffect(() => {
+  const controller = new AbortController()
+
+  void fetchProducts({ signal: controller.signal })
+
+  return () => controller.abort()
+}, [])
+```
+
+### 常見陷阱 / Common Pitfalls
+
+**陷阱 1: 缺 dependency 讓資料過期**
+
+```tsx
+// ❌ userId 變了也不會重新同步
+useEffect(() => {
+  void fetchOrders(userId)
+}, [])
+
+// ✅ dependency 反映 effect 使用的外部值
+useEffect(() => {
+  void fetchOrders(userId)
+}, [userId])
+```
+
+**陷阱 2: 為普通 callback 預設加 `useCallback`**
+
+```tsx
+// ❌ child 沒有 memo 時，穩定 callback 沒有實際收益
+const handleClick = useCallback(() => setOpen(true), [])
+return <RegularButton onClick={handleClick} />
+
+// ✅ 先保持直接
+return <RegularButton onClick={() => setOpen(true)} />
+```
+
+**推薦 ✅ - Backend handler 與 repository 各守邊界**:
+
+```go
+func (h *Handler) GetProduct(c *gin.Context) {
+	id := c.Param("id")
+	if !validateUUIDField(c, "id", id) {
+		return
+	}
+
+	product, err := h.productRepo.GetByID(c.Request.Context(), id)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, dto.ErrorResponse{
+			Success: false,
+			Error: dto.ErrorDetail{
+				Code:    dto.ErrCodeInternalServerError,
+				Message: "無法獲取商品",
+			},
+		})
+		return
+	}
+	if product == nil {
+		c.JSON(http.StatusNotFound, dto.ErrorResponse{
+			Success: false,
+			Error: dto.ErrorDetail{
+				Code:    dto.ErrCodeProductNotFound,
+				Message: "商品不存在",
+			},
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, dto.SuccessResponse{
+		Success: true,
+		Data:    dto.ToProductDetailResponse(product),
+	})
+}
+```
+
+### 參考現有實作 / Reference Implementation
+
+專案中的參考範例：
+
+- `apps/frontend/src/app/hooks/inventory-list/useInventoryPagination.ts` - 使用 memo 計算分頁顯示資料，並用 Effect 修正頁碼邊界。
+- `apps/frontend/src/app/hooks/inventory-list/useInventorySearch.ts` - 將搜尋字串整理放在 memo 計算內。
+- `apps/backend/internal/handler/product.go` - handler 先驗證 request，再呼叫 repository，最後回傳 DTO。
+- `apps/backend/internal/storage/sql/migration/scripts/` - migration 以 up/down 成對保存資料結構變更。
+
+### 自動化 / Automation
+
+- **ESLint**: `next/core-web-vitals` 與 `next/typescript` 會涵蓋 React Hooks 相關規則。
+- **TypeScript**: `pnpm --filter frontend run type-check`
+- **Go**: backend 變更後執行 `cd apps/backend && go test ./...`
+- **Git Hook**: Husky pre-commit 會執行 type-check 與 staged lint/format。
+
+---
+
+## 準則 13: 最小可行實作 / Guideline 13: Smallest Working Implementation
+
+### 說明 / Description
+
+選擇能解決當前問題的最小實作。不要預先加入框架、依賴、泛型層、設定檔或抽象層。新增複雜度前，先說明它解決的真實問題與取捨。
+
+Choose the smallest implementation that solves the current problem. Do not pre-add frameworks, dependencies, generic layers, config, or abstractions. Before adding complexity, state the real problem it solves and the trade-off.
+
+### 為什麼重要 / Why This Matters
+
+- **需要維護的部分更少**：依賴與抽象越少，維護面越小。
+- **回饋更快**：簡單實作比較容易 type-check、lint、build 與人工驗證。
+- **責任歸屬清楚**：工程師能理解為什麼這段 code 存在，以及何時該刪。
+
+### Linus 哲學 / Linus Philosophy
+
+Code must serve real problems. Future requirements with no evidence today should not become complexity that everyone must maintain today.
+
+### 檢查清單 / Checklist
+
+- [ ] 是否能用現有 helper 函式、component、type 或標準 API 解決？
+- [ ] 新依賴是否有明確必要性，且已確認專案尚未提供等價能力？
+- [ ] 新抽象是否至少有穩定重複或明確邊界需求？
+- [ ] 是否避免為「未來可能」新增 config、flag 或 generic framework？
+- [ ] 若是最佳化，是否有測量結果或可重現觀察支持？
+
+### 範例 / Examples
+
+**不推薦 ❌ - 為簡單需求新增抽象層**:
+
+```ts
+class DateLabelFormatter {
+  constructor(private locale: string) {}
+
+  format(value: Date) {
+    return value.toLocaleDateString(this.locale)
+  }
+}
+
+const dateLabelFormatter = new DateLabelFormatter('zh-TW')
+const label = dateLabelFormatter.format(value)
+```
+
+**推薦 ✅ - 優先使用標準 API 或既有依賴**:
+
+```ts
+export function formatDateLabel(value: Date) {
+  return new Intl.DateTimeFormat('zh-TW', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(value)
+}
+```
+
+**推薦 ✅ - 專案已有 `date-fns` 時再使用它**:
+
+```ts
+import { format } from 'date-fns'
+
+export function formatDateKey(value: Date) {
+  return format(value, 'yyyy-MM-dd')
+}
+```
+
+### 常見陷阱 / Common Pitfalls
+
+**陷阱 1: 第一次重複就抽象**
+
+```tsx
+// ❌ 模式尚未穩定就建立萬用工廠
+function createFormFieldRenderer(config: FieldConfig) {
+  return function FieldRenderer() {
+    return <input {...config} />
+  }
+}
+
+// ✅ 先寫清楚，等重複穩定再抽
+function ProductNameField(props: ProductNameFieldProps) {
+  return <Input value={props.value} onChange={props.onChange} />
+}
+```
+
+**陷阱 2: 泛型把領域語意洗掉**
+
+```ts
+// ❌ 呼叫端不知道 T、U、V 在 POS 領域代表什麼
+function processData<T, U, V>(data: T[], mapper: (item: T) => U): V[] {
+  return data.map(mapper) as V[]
+}
+
+// ✅ 讓函數名稱和型別保留領域語意
+function buildInventoryRows(items: IInventoryItem[]): IProduct[] {
+  return items.map(toProductViewModel)
+}
+```
+
+### 參考現有實作 / Reference Implementation
+
+專案中的參考範例：
+
+- `apps/frontend/src/app/components/atoms/` - 優先複用既有 shadcn/Radix-based primitive。
+- `apps/frontend/src/app/lib/utils.ts` - 通用 helper 函式集中在小範圍內，不為單一頁面擴張全域抽象。
+
+### 自動化 / Automation
+
+- **Package Scripts**: frontend 大改動後至少執行 `pnpm --filter frontend run type-check` 與 `pnpm --filter frontend run lint`。
+- **Go**: backend 大改動後至少執行 `cd apps/backend && go test ./...`。
+- **Git Hook**: Husky pre-commit 可攔截型別與 staged lint/format 問題。
+
+---
+
+## 相關文檔 / Related Documents
+
+- [AGENTS.md](../../AGENTS.md) - Linus Torvalds 開發哲學
+- [README.md](README.md) - 準則總覽
+- [01-component-standards.md](01-component-standards.md) - 組件生命週期與規範
+- [09-typescript.md](09-typescript.md) - TypeScript 專案規則
+- [apps/backend/SWAGGER.md](../../apps/backend/SWAGGER.md) - Backend API 文件更新流程
+- [apps/frontend/CLAUDE.md](../../apps/frontend/CLAUDE.md) - 前端專案開發規範
+
+---
+
+**最後更新 / Last Updated**: 2026-05-13
+**維護者 / Maintainer**: POS Team

--- a/.claude/rules/03-frontend-performance.md
+++ b/.claude/rules/03-frontend-performance.md
@@ -1,0 +1,940 @@
+---
+paths: ['**/*.tsx', '**/*.ts', '**/next.config.ts', '**/package.json']
+---
+
+# 前端效能 / Frontend Performance (準則 14-20)
+
+本文檔涵蓋 Next.js / React 前端的效能準則。內容聚焦可長期維護的通用做法，不以特定頁面或尚未定案的資料流程作為規則來源。
+
+This document covers frontend performance guidelines for Next.js / React applications. It focuses on maintainable general practices, not page-specific or still-unsettled data flows.
+
+---
+
+## 準則 14: 控制 Client Boundary 與 Lazy Loading / Guideline 14: Control Client Boundaries and Lazy Loading
+
+### 說明 / Description
+
+Next.js App Router 已自動按 route segment 拆分程式碼。此專案不以 SSR 作為主要效能策略；效能重點是控制 client runtime 邊界，並把瀏覽器專用或大型互動模組用 `next/dynamic` 做 lazy loading。
+
+Next.js App Router already code-splits by route segment. This project is not SSR-first; the key is to keep client runtime boundaries clear and load browser-only or heavy interactive modules with `next/dynamic` only when needed.
+
+### 為什麼重要 / Why This Matters
+
+- **初始載入更小**：瀏覽器只載入目前流程真正需要的互動程式碼。
+- **Hydration 成本更低**：只有真正需要互動的元件才進入 client bundle。
+- **錯誤邊界更清楚**：瀏覽器 API、拖曳、圖表、圖片預覽等行為集中在小元件中。
+- **審查更容易**：看到 `'use client'` 就能追問是否真的需要。
+
+### Linus 哲學 / Linus Philosophy
+
+> Solve a real problem. Keep the core simple.
+
+Do not use SSR, dynamic import, or page-wide client boundaries to hide a design problem. Keep interaction boundaries explicit; that is smaller, more direct, and easier to review.
+
+### 檢查清單 / Checklist
+
+- [ ] `page.tsx`、`layout.tsx` 是否避免把 SSR/RSC 當成預設資料策略？
+- [ ] `'use client'` 是否用在需要 hooks、事件或瀏覽器 API 的明確邊界？
+- [ ] 大型圖表、拖曳、檔案預覽、瀏覽器 API 是否被包在小型 client component？
+- [ ] 瀏覽器專用元件是否使用 `dynamic(..., { ssr: false })`，並有清楚原因？
+- [ ] `next/dynamic` 是否只用在有實際收益的重元件，而不是把簡單元件複雜化？
+- [ ] Loading / skeleton 是否在慢路徑上存在，避免空白畫面？
+
+### 範例 / Examples
+
+**不推薦 ❌ - 整頁 client 化並同步載入重元件**:
+
+```tsx
+'use client'
+
+import { HeavyChart } from './heavyChart'
+import { DragAndDropManager } from './dragAndDropManager'
+
+export default function ReportPage() {
+  return (
+    <>
+      <HeavyChart data={data} />
+      <DragAndDropManager items={items} onChange={setItems} />
+    </>
+  )
+}
+```
+
+**推薦 ✅ - 頁面入口保持薄，互動區塊清楚隔離**:
+
+```tsx
+import { ReportContent } from './reportContent'
+
+export default function ReportPage() {
+  return <ReportContent />
+}
+```
+
+```tsx
+'use client'
+
+import dynamic from 'next/dynamic'
+import { Skeleton } from './skeleton'
+
+const HeavyChart = dynamic(
+  () =>
+    import('./heavyChart').then((mod) => ({
+      default: mod.HeavyChart,
+    })),
+  {
+    loading: () => <Skeleton className="h-[300px] w-full" />,
+  }
+)
+
+export function ReportContent() {
+  return <HeavyChart />
+}
+```
+
+**推薦 ✅ - 瀏覽器 API 用 `ssr: false` 隔離**:
+
+```tsx
+import dynamic from 'next/dynamic'
+
+const ClientOnlyPreview = dynamic(
+  () =>
+    import('./clientOnlyPreview').then((mod) => ({
+      default: mod.ClientOnlyPreview,
+    })),
+  {
+    ssr: false,
+  }
+)
+```
+
+### 常見陷阱 / Common Pitfalls
+
+**陷阱 1: 為了使用一個 hook，把整個 route 都加上 `'use client'`**
+
+```tsx
+// ❌ 整頁都變成 client bundle
+'use client'
+
+export default function ExamplePage() {
+  const [open, setOpen] = useState(false)
+  return <ExampleLayout open={open} onOpenChange={setOpen} />
+}
+
+// ✅ 只有真正互動的區塊是 client component
+export default function ExamplePage() {
+  return <ExampleShell actions={<ExampleActions />} />
+}
+```
+
+**陷阱 2: 不分大小全部 dynamic import**
+
+```tsx
+// ❌ 簡單按鈕不需要 dynamic，反而增加理解成本
+const Button = dynamic(() => import('./button'))
+
+// ✅ dynamic 留給重元件、瀏覽器 API 或首屏非必要內容
+const DragAndDropManager = dynamic(() => import('./dragAndDropManager'))
+```
+
+### 維護備註 / Maintainer Notes
+
+不要把尚未定案的頁面或示範資料流程當成標準實作。審查時請找符合下列特徵的穩定範例：
+
+- 頁面入口保持薄，互動邏輯與瀏覽器 API 放在明確的小型 client component。
+- 需要 `window`、`document`、`URL.createObjectURL` 等瀏覽器 API 的元件有明確 client-only 邊界。
+- `next/dynamic` 只用於大型或瀏覽器專用模組，並提供 loading fallback。
+
+### 自動化 / Automation
+
+- **ESLint**: `next/core-web-vitals`、`next/typescript`
+- **Build Check**: `pnpm --filter frontend run build`
+- **Git Hook**: `lint-staged` 會處理 lint/format，但不取代 bundle 審查
+- **Manual Review**: 檢查 `'use client'` 邊界是否維持最小範圍
+
+---
+
+## 準則 15: 避免不必要的 Client State 與 Effect / Guideline 15: Avoid Unnecessary Client State and Effects
+
+### 說明 / Description
+
+React state 只用來保存會被使用者互動或非同步流程改變的資料。可以由 props、URL、remote/API data 或其他 state 推導出的值，不要再存一份 state。副作用集中在 `useEffect`，並且必須清理 timers、listeners、subscriptions、object URLs。
+
+Use React state only for data that changes through interaction or async flow. Do not duplicate values that can be derived from props, URL, remote/API data, or existing state. Keep side effects in `useEffect` and clean up timers, listeners, subscriptions, and object URLs.
+
+### 為什麼重要 / Why This Matters
+
+- **狀態越少，bug 越少**：重複 state 容易不同步。
+- **渲染次數更可控**：少一個 state update，就少一個可能的 render。
+- **記憶體更穩定**：object URL、listener、timer 沒清掉會累積。
+- **維護成本更低**：資料流明確，工程師不用猜哪份資料才是真的。
+
+### Linus 哲學 / Linus Philosophy
+
+> Good structure makes the code smaller, easier to test, and less fragile.
+
+Performance is not propped up by adding memo everywhere — it comes from a simple data model. Eliminate unnecessary state first, then talk about optimization.
+
+### 檢查清單 / Checklist
+
+- [ ] 是否有 state 可以直接由其他 state 或 props 推導？
+- [ ] `useEffect` 是否只處理副作用，而不是同步可推導資料？
+- [ ] timers、listeners、subscriptions、object URLs 是否都有 cleanup？
+- [ ] async effect 是否避免在 unmount 後更新 state？
+- [ ] `useEffect` dependency 是否完整，沒有靠忽略 lint 過關？
+
+### 範例 / Examples
+
+**不推薦 ❌ - 把可推導資料也存成 state**:
+
+```tsx
+const [items, setItems] = useState<Item[]>([])
+const [filteredItems, setFilteredItems] = useState<Item[]>([])
+const [totalCount, setTotalCount] = useState(0)
+
+useEffect(() => {
+  const nextItems = items.filter((item) => item.isVisible)
+  setFilteredItems(nextItems)
+  setTotalCount(nextItems.length)
+}, [items])
+```
+
+**推薦 ✅ - 直接推導，必要時才 memoize**:
+
+```tsx
+const [items, setItems] = useState<Item[]>([])
+
+const filteredItems = items.filter((item) => item.isVisible)
+const totalCount = filteredItems.length
+```
+
+**推薦 ✅ - 計算成本高或資料量大時才 `useMemo`**:
+
+```tsx
+const visibleItems = useMemo(
+  () => items.filter((item) => matchesSearch(item, searchQuery)),
+  [items, searchQuery]
+)
+```
+
+**推薦 ✅ - object URL 必須釋放**:
+
+```tsx
+useEffect(() => {
+  const urls = files.map((file) => URL.createObjectURL(file))
+  setImageUrls(urls)
+
+  return () => {
+    urls.forEach((url) => URL.revokeObjectURL(url))
+  }
+}, [files])
+```
+
+### 常見陷阱 / Common Pitfalls
+
+**陷阱 1: 用 effect 修補資料流**
+
+```tsx
+// ❌ searchQuery 改變後再同步另一份 state
+useEffect(() => {
+  setVisibleItems(items.filter((item) => item.name.includes(searchQuery)))
+}, [items, searchQuery])
+
+// ✅ render 時直接得到唯一真相
+const visibleItems = useMemo(
+  () => items.filter((item) => item.name.includes(searchQuery)),
+  [items, searchQuery]
+)
+```
+
+**陷阱 2: effect 沒清理**
+
+```tsx
+// ❌ listener 會殘留
+useEffect(() => {
+  window.addEventListener('resize', handleResize)
+}, [])
+
+// ✅ mount/unmount 對稱
+useEffect(() => {
+  window.addEventListener('resize', handleResize)
+
+  return () => {
+    window.removeEventListener('resize', handleResize)
+  }
+}, [handleResize])
+```
+
+### 維護備註 / Maintainer Notes
+
+不要引用仍在調整中的頁面或示範資料流程作為規則依據。審查時請找符合下列特徵的穩定範例：
+
+- State 只保存使用者互動或非同步流程會改變的資料。
+- 可由 props、URL、remote/API data 或既有 state 推導的資料直接計算，必要時才用 `useMemo`。
+- 瀏覽器資源、timer、listener、subscription 都有對稱 cleanup。
+
+### 自動化 / Automation
+
+- **ESLint**: `react-hooks/exhaustive-deps`
+- **Type Check**: `pnpm --filter frontend run type-check`
+- **Git Hook**: `lint-staged` 會執行 ESLint fix 與 Prettier
+- **Manual Review**: 檢查是否有可推導 state、缺少 cleanup 或不完整 dependency
+
+---
+
+## 準則 16: 先測量，再優化 / Guideline 16: Measure Before Optimizing
+
+### 說明 / Description
+
+效能優化必須從可觀察問題開始：頁面慢、互動卡、bundle 變大、API 請求過多、LCP/INP/CLS 退步。沒有測量，就不要用複雜 cache、全域 memo、virtualization 或重構來「感覺」會更快。
+
+Performance work must start from an observable problem: slow page load, janky interaction, bigger bundle, too many requests, or worse LCP/INP/CLS. Without measurement, do not add complex caches, global memoization, virtualization, or refactors just because they feel faster.
+
+### 為什麼重要 / Why This Matters
+
+- **避免錯修問題**：猜測通常會優化錯地方。
+- **保留可讀性**：不必要的優化會讓簡單邏輯變難懂。
+- **讓 Review 有證據**：before/after 數據比主觀感覺可靠。
+- **維持小變更**：測到瓶頸後才能做最小、可驗證的改動。
+
+### Linus 哲學 / Linus Philosophy
+
+> Theory and practice sometimes clash. Practice wins.
+
+Performance discussions are settled by measurement. A beautiful theory that does not improve what the user sees is not a good change.
+
+### 檢查清單 / Checklist
+
+- [ ] 是否能描述具體問題與使用者影響？
+- [ ] 優化前是否有 baseline：Chrome Performance、React Profiler、Lighthouse、Network 或 `next build`？
+- [ ] 優化後是否用同一方法重測？
+- [ ] PR / MR 是否寫清楚 before、after、取捨與剩餘風險？
+- [ ] 是否移除臨時 profiling code 與 `console.*`？
+
+### 範例 / Examples
+
+**不推薦 ❌ - 沒測量就加複雜 cache**:
+
+```tsx
+const recordCache = new Map<string, RecordItem[]>()
+const cacheStats = new Map<string, number>()
+
+export async function getRecords(groupId: string) {
+  if (recordCache.has(groupId)) {
+    cacheStats.set(groupId, (cacheStats.get(groupId) ?? 0) + 1)
+    return recordCache.get(groupId)
+  }
+
+  const records = await fetchRecords(groupId)
+  recordCache.set(groupId, records)
+  return records
+}
+```
+
+**推薦 ✅ - 先用最簡單的資料流，再測量瓶頸**:
+
+```tsx
+export async function getRecords(groupId: string) {
+  return fetchRecords(groupId)
+}
+```
+
+**推薦 ✅ - PR 中保留測量證據**:
+
+```markdown
+Problem:
+A list page takes 1.9s scripting time when rendering 1,500 rows.
+
+Change:
+Move initial render to paginated 50-row chunks.
+
+Verification:
+Chrome Performance, same dataset:
+
+- Before: 1.9s scripting, 1,508 DOM rows
+- After: 220ms scripting, 50 DOM rows
+```
+
+### 常見陷阱 / Common Pitfalls
+
+**陷阱 1: 把所有 handler 都包 `useCallback`**
+
+```tsx
+// ❌ 沒有 memo child，也沒有 effect dependency，沒有收益
+const handleClick = useCallback(() => {
+  setOpen(true)
+}, [])
+
+// ✅ 簡單函數直接寫
+const handleClick = () => {
+  setOpen(true)
+}
+```
+
+**陷阱 2: 優化後沒有重測**
+
+```markdown
+// ❌ PR description
+Improve chart performance.
+
+// ✅ PR description
+Chart filter interaction:
+
+- Before: React Profiler commit 180ms
+- After: React Profiler commit 42ms
+- Trade-off: chart data is memoized by range; memory increases by about 1 MB
+```
+
+### 維護備註 / Maintainer Notes
+
+不要把特定頁面目前的效能狀態當成通用標準。審查時請保存可重現的測量證據：
+
+- `next build` route size 或 bundle analyzer 結果。
+- Chrome Performance / React Profiler / Lighthouse 的 before/after。
+- PR / MR 說明中的問題、改動、驗證方式與取捨。
+
+### 自動化 / Automation
+
+- **Build**: `pnpm --filter frontend run build`
+- **Lint**: `pnpm --filter frontend run lint`
+- **Type Check**: `pnpm --filter frontend run type-check`
+- **Manual Profiling**: Chrome DevTools Performance、React DevTools Profiler、Lighthouse
+- **Manual Review**: PR / MR 需保留效能問題、before/after、取捨與剩餘風險
+
+---
+
+## 準則 17: 避免 N+1 請求與 Waterfall / Guideline 17: Avoid N+1 Requests and Data Waterfalls
+
+### 說明 / Description
+
+批次資料應該用單次 API 或可並行的查詢取得，不要在 loop、`useEffect` 或 component tree 中逐層發 request。此專案不以 SSR 資料組裝作為預設策略；若真的需要 server runtime，仍必須避免序列化等待造成 waterfall。
+
+Batch data should be fetched with one API or parallel queries. Do not issue one request per item inside loops, `useEffect`, or nested component trees. This project is not SSR-first; if server runtime is used, sequential awaits can still create waterfalls.
+
+### 為什麼重要 / Why This Matters
+
+- **速度**：N+1 在資料量上來後會直接放大延遲。
+- **API 壓力**：多餘 request 會浪費連線與處理成本。
+- **使用者體驗**：waterfall 會讓 loading 一段接一段出現。
+- **資料模型更清楚**：批次 API 迫使呼叫端與 API provider 定義真正需要的資料形狀。
+
+### Linus 哲學 / Linus Philosophy
+
+> Design the data model and boundaries first.
+
+If the screen needs primary data, related state, and display config, define an interface that fetches them in one call or in parallel. Do not push gaps in the API contract onto the UI to fill with N separate requests.
+
+### 檢查清單 / Checklist
+
+- [ ] 是否在 `map`、`for`、`forEach` 中呼叫 API？
+- [ ] 是否能用 batch endpoint，例如 `/api/items?ids=...`？
+- [ ] 多個互不依賴的 request 是否用 `Promise.all` 並行？
+- [ ] Client component 是否把初始資料抓取放進 `useEffect`，導致首屏空白？
+- [ ] loading、error、empty state 是否由同一層資料邊界管理？
+
+### 範例 / Examples
+
+**不推薦 ❌ - loop 中逐筆請求**:
+
+```tsx
+const items = await itemApi.getAll()
+
+for (const item of items) {
+  item.status = await statusApi.getByItemId(item.id)
+}
+```
+
+**推薦 ✅ - batch API 回傳畫面需要的資料**:
+
+```tsx
+const items = await itemApi.getAll()
+const itemIds = items.map((item) => item.id)
+const statuses = await statusApi.getBatchByItemIds(itemIds)
+
+const statusByItemId = new Map(
+  statuses.map((status) => [status.itemId, status])
+)
+
+return items.map((item) => ({
+  ...item,
+  status: statusByItemId.get(item.id) ?? null,
+}))
+```
+
+**推薦 ✅ - 互不依賴的資料並行取得**:
+
+```tsx
+export default async function DashboardPage() {
+  const [items, groups, summary] = await Promise.all([
+    itemApi.getAll(),
+    groupApi.getAll(),
+    reportApi.getSummary(),
+  ])
+
+  return <Dashboard items={items} groups={groups} summary={summary} />
+}
+```
+
+### 常見陷阱 / Common Pitfalls
+
+**陷阱 1: Client component mount 後才抓首屏資料**
+
+```tsx
+// ❌ 首屏先空白，再由瀏覽器發 request
+'use client'
+
+export function ItemTable() {
+  const [items, setItems] = useState<Item[]>([])
+
+  useEffect(() => {
+    itemApi.getAll().then(setItems)
+  }, [])
+
+  return <Table items={items} />
+}
+
+// ✅ 將遠端資料生命週期集中在 adapter 或 query hook
+export function ItemTable() {
+  const { data: items = [], isLoading } = useItemsQuery()
+
+  if (isLoading) {
+    return <TableSkeleton />
+  }
+
+  return <Table items={items} />
+}
+```
+
+**陷阱 2: 非必要的序列等待**
+
+```tsx
+// ❌ 第二個 request 不依賴第一個，卻被迫等待
+const items = await itemApi.getAll()
+const groups = await groupApi.getAll()
+
+// ✅ 並行
+const [items, groups] = await Promise.all([itemApi.getAll(), groupApi.getAll()])
+```
+
+### 維護備註 / Maintainer Notes
+
+不要以尚未接 API 的頁面或示範資料流程作為資料存取標準。審查時請確認資料邊界具備下列特徵：
+
+- 初始頁面資料策略要明確；預設不要為了避免 client fetch 就引入 SSR/RSC。
+- API contract 支援批次查詢或並行查詢，不要求 component tree 自行補 N 次 request。
+- 資料轉換集中在 adapter、loader 或 hook，避免散落在多個 UI component。
+
+### 自動化 / Automation
+
+- **Network Tab**: 檢查同一互動是否產生大量相似 request。
+- **Code Review**: 搜尋 `await` inside loop、`fetch` inside `map`、mount-only `useEffect` fetch。
+- **Manual Review**: loop 內 API 呼叫必須改成 batch API 或並行查詢。
+
+---
+
+## 準則 18: Memoization 服務資料流，不服務焦慮 / Guideline 18: Memoization Serves Data Flow, Not Anxiety
+
+### 說明 / Description
+
+`useMemo`、`useCallback`、`React.memo` 是工具，不是預設樣板。只有在計算昂貴、引用穩定性真的影響 memo child、或 profiling 顯示 render 成本過高時才使用。依賴陣列必須完整，memoized function 不應隱藏副作用。
+
+`useMemo`, `useCallback`, and `React.memo` are tools, not default boilerplate. Use them only for expensive computation, stable references required by memoized children, or measured render cost. Dependency arrays must be complete, and memoized functions must not hide side effects.
+
+### 為什麼重要 / Why This Matters
+
+- **可讀性**：過量 memo 讓簡單邏輯變難讀。
+- **正確性**：錯誤 dependency 會產生 stale closure。
+- **實際成本**：memo 本身也有成本，不是免費。
+- **Review 更快**：只有有理由的 memo 才需要被審查。
+
+### Linus 哲學 / Linus Philosophy
+
+> Maintainability beats cleverness.
+
+Adding memo everywhere is overengineering. Good taste is understanding the data flow and reserving necessary optimization for genuinely expensive places.
+
+### 檢查清單 / Checklist
+
+- [ ] 使用 `useMemo` 前是否能說明計算成本或引用穩定需求？
+- [ ] 使用 `useCallback` 前，是否傳給 `React.memo` child 或被 effect dependency 使用？
+- [ ] `React.memo` 的 component 是否 render 成本高、props 穩定、且有測量證據？
+- [ ] dependency array 是否完整，沒有 stale closure？
+- [ ] 是否能用拆分 component 或簡化 state 取代 memo？
+
+### 範例 / Examples
+
+**不推薦 ❌ - 無理由 memoization**:
+
+```tsx
+const total = useMemo(() => price * quantity, [price, quantity])
+
+const handleOpen = useCallback(() => {
+  setOpen(true)
+}, [])
+```
+
+**推薦 ✅ - 簡單計算直接寫**:
+
+```tsx
+const total = price * quantity
+
+const handleOpen = () => {
+  setOpen(true)
+}
+```
+
+**推薦 ✅ - 大量資料過濾才 memoize**:
+
+```tsx
+const visibleItems = useMemo(
+  () =>
+    items.filter((item) =>
+      item.name.toLowerCase().includes(searchQuery.toLowerCase())
+    ),
+  [items, searchQuery]
+)
+```
+
+**推薦 ✅ - memo child 需要穩定 callback**:
+
+```tsx
+const ExpensiveListItem = memo(function ExpensiveListItem({
+  item,
+  onSelect,
+}: ExpensiveListItemProps) {
+  return <button onClick={() => onSelect(item.id)}>{item.name}</button>
+})
+
+function ItemList({ items }: ItemListProps) {
+  const handleSelect = useCallback((itemId: string) => {
+    setSelectedItemId(itemId)
+  }, [])
+
+  return items.map((item) => (
+    <ExpensiveListItem key={item.id} item={item} onSelect={handleSelect} />
+  ))
+}
+```
+
+### 常見陷阱 / Common Pitfalls
+
+**陷阱 1: dependency 不完整**
+
+```tsx
+// ❌ searchQuery 變了，結果不會更新
+const visibleItems = useMemo(
+  () => items.filter((item) => item.name.includes(searchQuery)),
+  [items]
+)
+
+// ✅ dependency 完整
+const visibleItems = useMemo(
+  () => items.filter((item) => item.name.includes(searchQuery)),
+  [items, searchQuery]
+)
+```
+
+**陷阱 2: `React.memo` 包住總是變動的 props**
+
+```tsx
+// ❌ 每次 render 都產生新物件，memo child 仍會重 render
+<Chart options={{ height: 300, color: 'brand' }} />
+
+// ✅ options 是穩定常數，或直接拆成 primitive props
+const chartOptions = { height: 300, color: 'brand' } as const
+
+<Chart options={chartOptions} />
+```
+
+### 維護備註 / Maintainer Notes
+
+不要用特定頁面目前是否有 `memo` 作為通用依據。審查時請確認 memoization 符合下列條件：
+
+- render 成本已被 React Profiler 或可重現操作證明。
+- props 引用穩定，`React.memo` 不是包住每次都變的新物件。
+- dependency array 完整，沒有為了「少 render」犧牲正確性。
+
+### 自動化 / Automation
+
+- **ESLint**: `react-hooks/exhaustive-deps`
+- **Profiler**: React DevTools Profiler 確認 render 成本。
+- **Code Review**: 看到 memo/useMemo/useCallback 必須能回答「瓶頸在哪」。
+
+---
+
+## 準則 19: 大列表先分頁，再考慮虛擬捲動 / Guideline 19: Paginate Large Lists Before Virtualizing
+
+### 說明 / Description
+
+一般列表先使用分頁、搜尋與篩選縮小 render 範圍；當單頁仍需呈現大量列、拖曳排序或複雜 cell 時，才引入 virtualization。遠端資料量大時，優先要求 API 支援分頁，不要一次把全部資料丟給瀏覽器。
+
+Use pagination, search, and filters first to reduce render scope. Add virtualization only when a page still renders many rows, drag-and-drop items, or complex cells. For large remote datasets, prefer API pagination over sending everything to the browser.
+
+### 為什麼重要 / Why This Matters
+
+- **DOM 節點可控**：畫面只渲染使用者需要看的資料。
+- **互動更穩定**：大量列會放大 checkbox、popover、dialog、drag sensor 的成本。
+- **實作更簡單**：分頁比 virtualization 更容易測試與維護。
+- **API 契約清楚**：真正大資料要在 API 層支援 page、limit、sort、filter。
+
+### Linus 哲學 / Linus Philosophy
+
+> Prefer clear invariants over clever control flow.
+
+"At most N items per page" is a clear invariant; virtual scrolling is a more complex UI technique. Solve the problem with data boundaries first, and only upgrade when that is not enough.
+
+### 檢查清單 / Checklist
+
+- [ ] 列表是否有明確的 `page`、`pageSize`、`totalCount`？
+- [ ] key 是否使用穩定 ID，而不是 array index？
+- [ ] 篩選、搜尋、排序是否在資料量大時能交給 API？
+- [ ] 單頁渲染是否超過 100-200 筆複雜列？若是，是否有測量證據？
+- [ ] 若引入 virtualization，是否處理好 row height、focus、keyboard navigation、empty/loading state？
+
+### 範例 / Examples
+
+**不推薦 ❌ - 一次渲染所有資料**:
+
+```tsx
+export function DataTable({ items }: DataTableProps) {
+  return (
+    <tbody>
+      {items.map((item) => (
+        <DataRow key={item.id} item={item} />
+      ))}
+    </tbody>
+  )
+}
+```
+
+**推薦 ✅ - 先分頁再渲染**:
+
+```tsx
+export function DataTable({ currentItems }: DataTableProps) {
+  return (
+    <tbody>
+      {currentItems.map((item) => (
+        <DataRow key={item.id} item={item} />
+      ))}
+    </tbody>
+  )
+}
+```
+
+**推薦 ✅ - API 分頁契約**:
+
+```tsx
+interface ListQuery {
+  page: number
+  pageSize: number
+  searchQuery?: string
+  groupIds?: string[]
+}
+
+interface ListResult<TItem> {
+  items: TItem[]
+  totalCount: number
+}
+```
+
+### 常見陷阱 / Common Pitfalls
+
+**陷阱 1: 用 index 當 key**
+
+```tsx
+// ❌ 搜尋、排序、刪除後容易造成錯誤重用
+items.map((item, index) => <DataRow key={index} item={item} />)
+
+// ✅ 穩定 ID
+items.map((item) => <DataRow key={item.id} item={item} />)
+```
+
+**陷阱 2: 太早導入 virtualization**
+
+```tsx
+// ❌ 只有 20 筆資料也引入 virtualization，增加測試與可及性成本
+<VirtualizedTable items={items.slice(0, 20)} />
+
+// ✅ 小列表直接渲染，維持簡單
+<DataTable currentItems={currentItems} />
+```
+
+### 維護備註 / Maintainer Notes
+
+不要因為目前某個頁面有前端分頁，就把它視為所有資料量情境的標準答案。審查時請確認：
+
+- 小資料量直接渲染，維持簡單。
+- 中等資料量先使用前端或 API 分頁，明確限制每次 render 的項目數。
+- 大資料量或複雜 row 需要測量證據，再引入 virtualization。
+
+### 自動化 / Automation
+
+- **Code Review**: 搜尋 `.map(` 渲染大型資料、`key={index}`、未分頁 table。
+- **Performance Monitor**: 觀察 DOM nodes、scripting time、interaction latency。
+- **Manual Review**: 大量 list render 先確認 pagination / API pagination，再討論 virtualization。
+
+---
+
+## 準則 20: Bundle 與資產大小要可見 / Guideline 20: Keep Bundle and Assets Visible
+
+### 說明 / Description
+
+Bundle 檢查以 `next build` 輸出的 route size、Chrome Coverage、Network、Lighthouse 或需要時加入 `@next/bundle-analyzer` 為準。圖片使用 `next/image`，字體使用 `next/font`，第三方大型套件要 lazy load 或拆到 client boundary。
+
+Use `next build` route size output, Chrome Coverage, Network, Lighthouse, or `@next/bundle-analyzer` when needed. Use `next/image` for images, `next/font` for fonts, and lazy-load large third-party packages or isolate them behind client boundaries.
+
+### 為什麼重要 / Why This Matters
+
+- **載入速度**：bundle 與圖片越大，首屏越慢。
+- **行動網路成本**：使用者可能在不同設備與網路環境使用。
+- **快取效率**：穩定拆分讓瀏覽器更容易重用資源。
+- **可維護性**：明確知道大型依賴在哪裡進入 bundle。
+
+### Linus 哲學 / Linus Philosophy
+
+> Make the code reviewable.
+
+When adding a large dependency or asset, reviewers should be able to see the reason, size impact, and alternatives. Do not let bundle growth hide inside "just changing one import line".
+
+### 檢查清單 / Checklist
+
+- [ ] 是否跑過 `pnpm --filter frontend run build` 並檢查 route size？
+- [ ] 新增依賴是否有必要，是否已有現成專案工具可用？
+- [ ] 大型套件是否可 lazy load，例如圖表、拖曳、日期處理？
+- [ ] 圖片是否使用 `next/image`，並提供 `width`、`height`、`alt`？
+- [ ] LCP 圖片是否使用 `priority`，非首屏圖片是否避免 priority？
+- [ ] 遠端圖片來源是否在 `next.config.ts` 的 `images.remotePatterns` 中明確配置？
+- [ ] 字體是否透過 `next/font` 或 local font 載入，避免 layout shift？
+
+### 範例 / Examples
+
+**不推薦 ❌ - 原生 `<img>` 與未定尺寸圖片**:
+
+```tsx
+export function OptimizedImage({ src, label }: OptimizedImageProps) {
+  return <img src={src} alt={label} />
+}
+```
+
+**推薦 ✅ - 使用 `next/image`**:
+
+```tsx
+import Image from 'next/image'
+
+export function OptimizedImage({ src, label }: OptimizedImageProps) {
+  return (
+    <Image
+      src={src}
+      width={100}
+      height={100}
+      className="h-24 w-24 rounded-md object-cover"
+      alt={label}
+    />
+  )
+}
+```
+
+**推薦 ✅ - 字體使用 `next/font/local`**:
+
+```tsx
+import localFont from 'next/font/local'
+
+const appSans = localFont({
+  src: './fonts/AppSans.woff2',
+  variable: '--font-app-sans',
+  weight: '100 900',
+})
+```
+
+**推薦 ✅ - 檢查 Next build 輸出**:
+
+```bash
+pnpm --filter frontend run build
+```
+
+### 常見陷阱 / Common Pitfalls
+
+**陷阱 1: 使用不符合專案建置工具的 analyzer**
+
+效能檢查應使用專案實際建置工具提供的輸出與 analyzer。
+
+```bash
+# ✅ 先看 Next build route size；需要深入再加 bundle analyzer
+pnpm --filter frontend run build
+```
+
+**陷阱 2: 圖片來源沒配置**
+
+```tsx
+// ❌ 遠端圖片沒有 remotePatterns 時，next/image 會失敗
+;<Image
+  src="https://cdn.example.com/product.png"
+  width={100}
+  height={100}
+  alt="product"
+/>
+
+// ✅ 在 next.config.ts 明確允許來源
+const nextConfig: NextConfig = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'cdn.example.com',
+      },
+    ],
+  },
+}
+```
+
+### 維護備註 / Maintainer Notes
+
+不要把某個頁面的圖片、字體或圖表實作當成通用規則。審查時請確認：
+
+- 遠端圖片來源在 `next.config.ts` 中明確允許，且範圍不過寬。
+- 字體透過 `next/font` 管理，避免額外 layout shift。
+- 大型第三方 UI / chart / editor / drag-and-drop 套件有 route size 或 analyzer 證據。
+
+### 自動化 / Automation
+
+- **Build**: `pnpm --filter frontend run build`
+- **Coverage**: Chrome DevTools Coverage 檢查 unused JavaScript。
+- **Lighthouse**: 檢查 LCP、INP、CLS、image sizing。
+- **Bundle Analyzer**: 只有在 bundle 成長或審查需要時加入 `@next/bundle-analyzer`。
+- **Manual Review**: 新增大型依賴、原生 `<img>` 或 analyzer 設定時，需說明原因與大小影響。
+
+---
+
+## 總結 / Summary
+
+前端效能的 7 條準則核心思想：
+
+1. **準則 14**: 控制 client boundary，重元件與瀏覽器 API 才 lazy load。
+2. **準則 15**: 減少不必要 state/effect，讓資料流維持單一真相。
+3. **準則 16**: 先測量再優化，PR 必須能說清 before/after。
+4. **準則 17**: 批次請求與並行資料取得，避免 N+1 和 waterfall。
+5. **準則 18**: Memoization 要有理由，服務資料流而不是焦慮。
+6. **準則 19**: 大列表先分頁與 API 分頁，再考慮虛擬捲動。
+7. **準則 20**: Bundle、圖片、字體、第三方依賴都要可見、可審查。
+
+**Linus 哲學 / Linus Philosophy in Frontend Performance**:
+
+- **Solve a Real Problem** → 準則 16（沒有測量就不要優化）
+- **Keep the Core Simple** → 準則 14、15、18（縮小 client boundary、減少 state、避免無理由 memo）
+- **Design the Data Model First** → 準則 17、19（批次資料、分頁契約）
+- **Make the Code Reviewable** → 準則 20（bundle 與資產變化要有證據）
+
+---
+
+## 相關文檔 / Related Documents
+
+- [Next.js App Router Documentation](https://nextjs.org/docs/app)
+- [Next.js Image Optimization](https://nextjs.org/docs/app/getting-started/images)
+- [Next.js Font Optimization](https://nextjs.org/docs/app/getting-started/fonts)
+- [React Performance](https://react.dev/reference/react/useMemo)
+- [README.md](README.md) - 準則總覽
+- [AGENTS.md](../../AGENTS.md) - 專案工程原則
+
+---
+
+**最後更新 / Last Updated**: 2026-05-16  
+**維護者 / Maintainer**: Frontend Team

--- a/.claude/rules/04-frontend-security.md
+++ b/.claude/rules/04-frontend-security.md
@@ -1,0 +1,670 @@
+---
+paths:
+  [
+    'apps/frontend/src/**/*.tsx',
+    'apps/frontend/src/**/*.ts',
+    'apps/frontend/.eslintrc.json',
+    'apps/frontend/next.config.ts',
+    'apps/frontend/package.json',
+    'package.json',
+    'pnpm-lock.yaml',
+    'pnpm-workspace.yaml',
+  ]
+---
+
+# 前端安全 / Frontend Security (準則 21-25)
+
+本文檔涵蓋 React / Next.js / TypeScript / pnpm 前端的安全準則。核心目標是把瀏覽器、server/API 的責任切清楚：瀏覽器裡的程式碼可以改善 UX，但不能成為安全來源。
+
+This document covers security guidelines for React / Next.js / TypeScript / pnpm frontends. The core goal is to make trust boundaries explicit: browser code can improve UX, but it cannot be the source of security truth.
+
+---
+
+## 準則 21: 跨站腳本攻擊（XSS）防護 / Guideline 21: XSS Protection
+
+### 說明 / Description
+
+預設把 API 回傳、URL 參數、使用者輸入、CMS 內容和第三方資料都視為不可信資料。React JSX 的文字插值會自動轉義，應優先渲染純文字。避免 `dangerouslySetInnerHTML`、`innerHTML`、`outerHTML`、`eval()` 和 `new Function()`。
+
+若真的需要渲染 HTML，需求必須能被 review：集中在一個邊界做清理，限制允許的 HTML tag / attribute，並在同一個變更中加入或指定已核准的 sanitizer。不要把 HTML 清理邏輯散在多個 component。
+
+Treat API responses, URL params, user input, CMS content, and third-party data as untrusted. React JSX text interpolation escapes by default, so render plain text first. Avoid `dangerouslySetInnerHTML`, `innerHTML`, `outerHTML`, `eval()`, and `new Function()`.
+
+If rendering HTML is truly required, make the requirement reviewable: sanitize at one boundary, restrict allowed tags and attributes, and add or identify the approved sanitizer in the same change. Do not spread HTML sanitization across many components.
+
+### 為什麼重要 / Why This Matters
+
+- **Session 風險**：XSS 可以冒用使用者在站內操作；即使 token 放在 `HttpOnly` cookie，也不是免疫。
+- **簡單預設**：JSX 文字渲染已經是安全預設，不需要額外抽象。
+- **可審查性**：HTML 例外集中在一處，reviewer 才能看懂允許範圍與風險。
+
+### Linus 哲學 / Linus Philosophy
+
+> "Prefer clear invariants over clever control flow."
+
+The invariant here is simple: untrusted data may only be rendered as plain text by default. HTML rendering is an exception, and exceptions must be centralized and verifiable.
+
+### 檢查清單 / Checklist
+
+- [ ] 是否優先用 JSX 文字插值渲染不可信資料？
+- [ ] 是否避免直接把不可信資料傳給 `dangerouslySetInnerHTML`？
+- [ ] 若必須渲染 HTML，是否集中清理並限制允許的 tag / attribute？
+- [ ] 是否避免 `eval()`、`new Function()`、`innerHTML`、`outerHTML`？
+- [ ] URL、redirect、`href`、`src` 是否限制 protocol、origin，或使用允許清單（allowlist；常見說法是白名單）？
+
+### 範例 / Examples
+
+**不推薦 ❌ - 直接渲染不可信 HTML**:
+
+```tsx
+type CommentProps = {
+  html: string
+}
+
+export function Comment({ html }: CommentProps) {
+  return <div dangerouslySetInnerHTML={{ __html: html }} />
+}
+```
+
+**推薦 ✅ - 預設渲染純文字**:
+
+```tsx
+type CommentProps = {
+  text: string
+}
+
+export function Comment({ text }: CommentProps) {
+  return <div>{text}</div>
+}
+```
+
+**推薦 ✅ - 必須渲染 HTML 時集中處理**:
+
+下例的 `approvedHtmlSanitizer` 代表已完成審查的 sanitizer 封裝。若專案尚未導入 sanitizer，應先完成套件評估與允許清單設計，不要手刻 HTML parser。
+
+```tsx
+type SafeHtmlProps = {
+  html: string
+}
+
+function sanitizeRichTextHtml(html: string): string {
+  return approvedHtmlSanitizer(html, {
+    allowedTags: ['p', 'strong', 'em', 'a'],
+    allowedAttributes: {
+      a: ['href', 'rel', 'target'],
+    },
+  })
+}
+
+export function SafeHtml({ html }: SafeHtmlProps) {
+  return (
+    <div dangerouslySetInnerHTML={{ __html: sanitizeRichTextHtml(html) }} />
+  )
+}
+```
+
+### 常見陷阱 / Common Pitfalls
+
+**陷阱 1: 開放重新導向（open redirect）**
+
+```typescript
+// ❌ URL 參數直接用於跳轉
+const next = searchParams.get('next')
+window.location.href = next ?? '/'
+
+// ✅ 只允許同 origin（同來源）的相對路徑
+function getSafeInternalPath(value: string | null): string {
+  if (!value) return '/'
+
+  try {
+    const url = new URL(value, window.location.origin)
+    if (url.origin !== window.location.origin) return '/'
+
+    return `${url.pathname}${url.search}${url.hash}`
+  } catch {
+    return '/'
+  }
+}
+
+window.location.href = getSafeInternalPath(searchParams.get('next'))
+```
+
+**陷阱 2: 用字串組出可執行邏輯**
+
+```typescript
+// ❌ 任意字串都可能變成可執行程式碼
+const handler = new Function(userInput)
+handler()
+
+// ✅ 用明確分支處理允許的行為
+const allowedActions = {
+  close: () => closeDialog(),
+  submit: () => submitForm(),
+}
+
+if (actionName === 'close' || actionName === 'submit') {
+  allowedActions[actionName]()
+}
+```
+
+### 參考現有實作 / Reference Implementation
+
+通用檢查位置：
+
+- `apps/frontend/src/app/**/*.tsx` - component 應優先使用 JSX 文字插值。
+- `apps/frontend/src/app/**/*.ts` - URL、redirect、資料轉換邊界應集中驗證。
+- `apps/frontend/package.json` 目前未列出已核准的 HTML sanitizer；若新增 HTML 渲染需求，必須在同一個變更中說明 sanitizer 與允許範圍。
+
+### 自動化 / Automation
+
+- **ESLint**: `next/core-web-vitals`、`next/typescript` 可檢查 React / Next.js 基礎問題；XSS 仍需人工 review。
+- **Manual Review**: 搜尋 `dangerouslySetInnerHTML`、`innerHTML`、`outerHTML`、`eval(`、`new Function`。
+- **Git Hook**: ℹ️ 目前 hook 只做 type-check、staged lint/format 與 commitlint，未阻擋所有 XSS 風險。
+- **Claude Hook**: ℹ️ `check-guidelines.sh` 是提醒腳本，不是完整安全掃描。
+
+---
+
+## 準則 22: 輸入驗證 / Guideline 22: Input Validation
+
+### 說明 / Description
+
+前端驗證只負責 UX：即時提示、disabled button、基本格式檢查。真正的安全驗證必須在後端、Next.js Route Handler、Server Action，或任何接收資料的 server/API 邊界重做。TypeScript 型別只是編譯期輔助，不是 runtime（執行期）驗證。
+
+Client-side validation is for UX only: instant feedback, disabled buttons, and basic format checks. Security validation must happen on the backend, Next.js Route Handler, Server Action, or any service boundary that receives data. TypeScript types help at compile time; they are not runtime validation.
+
+### 為什麼重要 / Why This Matters
+
+- **可繞過性**：瀏覽器裡的程式碼可被開發者工具、腳本或直接 API 呼叫繞過。
+- **資料完整性**：可信任的 server/API 邊界才有權決定金額、權限、狀態轉換與資料約束。
+- **錯誤可診斷**：前後端邊界清楚，錯誤來源才容易定位。
+
+### Linus 哲學 / Linus Philosophy
+
+> "Design the data model and boundaries first."
+
+Validation is not a form decoration — it is a data boundary. The frontend can provide early feedback, but security rules must be enforced again at the server/API boundary.
+
+### 檢查清單 / Checklist
+
+- [ ] 前端驗證是否只被描述為 UX，不被當成安全機制？
+- [ ] 後端或 server/API 邊界是否重新驗證資料型別、範圍、格式與權限？
+- [ ] 是否避免信任 hidden input、disabled field、client state 或 query string？
+- [ ] 金額、角色、權限、配額、狀態轉換是否由 server/API 邊界計算或驗證？
+- [ ] 後端驗證錯誤是否有清楚且可顯示的錯誤碼或訊息？
+
+### 範例 / Examples
+
+**不推薦 ❌ - 只靠前端 disable button**:
+
+```tsx
+function EmailForm() {
+  const [email, setEmail] = useState('')
+  const isValid = email.includes('@')
+
+  return (
+    <form onSubmit={() => submitEmail({ email })}>
+      <input value={email} onChange={(event) => setEmail(event.target.value)} />
+      <button disabled={!isValid}>Submit</button>
+    </form>
+  )
+}
+```
+
+**推薦 ✅ - 前端做 UX 檢核，提交後仍處理 server/API 邊界錯誤**:
+
+```tsx
+function EmailForm() {
+  const [email, setEmail] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const isValidEmail = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    if (!isValidEmail) return
+
+    const result = await submitEmail({ email })
+    if (!result.ok) {
+      setError(result.message)
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <input value={email} onChange={(event) => setEmail(event.target.value)} />
+      {error ? <p>{error}</p> : null}
+      <button disabled={!isValidEmail}>Submit</button>
+    </form>
+  )
+}
+```
+
+**推薦 ✅ - server/API 邊界重新驗證**:
+
+```typescript
+type SubmitEmailInput = {
+  email: unknown
+}
+
+export function parseSubmitEmailInput(input: SubmitEmailInput) {
+  if (typeof input.email !== 'string') {
+    throw new Error('INVALID_EMAIL')
+  }
+
+  const email = input.email.trim()
+  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+    throw new Error('INVALID_EMAIL')
+  }
+
+  return { email }
+}
+```
+
+### 常見陷阱 / Common Pitfalls
+
+**陷阱 1: 信任前端計算的金額或權限**
+
+```typescript
+// ❌ total / role 由瀏覽器提交，可以被竄改
+await submitRequest({ resourceIds, total, role })
+
+// ✅ 提交最小可驗證資料，由 server/API 邊界重新計算與授權
+await submitRequest({ resourceIds })
+```
+
+**陷阱 2: 把 TypeScript type 當 runtime（執行期）驗證**
+
+```typescript
+type ProfileInput = {
+  displayName: string
+}
+
+// ❌ assertion 不會檢查執行期資料
+const input = JSON.parse(rawBody) as ProfileInput
+
+// ✅ 解析 unknown，再逐項驗證
+const parsed: unknown = JSON.parse(rawBody)
+if (!isProfileInput(parsed)) {
+  throw new Error('INVALID_PROFILE_INPUT')
+}
+```
+
+### 參考現有實作 / Reference Implementation
+
+通用檢查位置：
+
+- `apps/frontend/src/app/types/**/*.ts` - TypeScript types 只代表編譯期契約。
+- `apps/frontend/src/app/hooks/**/*.ts` - hook 中的驗證應定位為 UX 或資料整理。
+- Route Handler / Server Action / server/API 邊界若新增到專案，需在接收資料處重新驗證。
+
+### 自動化 / Automation
+
+- **TypeScript**: ✅ 可檢查編譯期型別，不等於 runtime（執行期）驗證。
+- **ESLint**: ✅ 可檢查部分型別、Hooks 與 React / Next.js 問題；不能替代 runtime（執行期）驗證。
+- **Contract Tests**: ℹ️ 若有後端或 API contract，應補上邊界驗證測試。
+- **Claude Hook**: ℹ️ `check-guidelines.sh` 目前會提醒準則 22。
+
+---
+
+## 準則 23: 敏感資料處理 / Guideline 23: Sensitive Data Handling
+
+### 說明 / Description
+
+不要把 secret、密碼、API key、refresh token 或不可公開資料放進前端 bundle、瀏覽器裡可被 JavaScript 讀到的 storage、URL、log 或 mock data。`NEXT_PUBLIC_*` 變數會進入前端 bundle，必須視為公開資訊。auth token / session 優先由後端以 `HttpOnly; Secure; SameSite` cookie 管理，前端只透過同源 API 或受控 proxy 存取需要 secret 的服務。
+
+Do not put secrets, passwords, API keys, refresh tokens, or non-public data in the client bundle, browser-readable storage, URLs, logs, or mock data. `NEXT_PUBLIC_*` variables are shipped to the browser and must be treated as public. Auth tokens should be set by the backend as `HttpOnly; Secure; SameSite` cookies, and the frontend should access secret-backed services through same-origin APIs or controlled proxies.
+
+### 為什麼重要 / Why This Matters
+
+- **XSS 放大效應**：`localStorage` 和 `sessionStorage` 可被成功執行的前端腳本讀取。
+- **前端 bundle 不可保密**：前端程式碼和 `NEXT_PUBLIC_*` 環境變數可被使用者檢視。
+- **外洩面積**：URL、console、mock data 和錯誤回報常被第三方系統保存。
+
+### Linus 哲學 / Linus Philosophy
+
+> "Keep the core simple."
+
+The core rule for sensitive data handling is small: secrets do not enter the browser. Actions that require secrets belong at the server/API boundary, not patched with a collection of special cases in the frontend.
+
+### 檢查清單 / Checklist
+
+- [ ] 是否避免把 token、secret、password、private API key 放進 `localStorage` 或 `sessionStorage`？
+- [ ] 是否避免把敏感資料放進 `NEXT_PUBLIC_*`、前端程式碼或 mock data？
+- [ ] Session / auth cookie 是否由後端設定 `HttpOnly`、`Secure`、`SameSite`？
+- [ ] 是否避免在 URL query、hash、path 傳遞敏感資料？
+- [ ] log、toast、error message 是否避免輸出完整個資、token 或 secret？
+
+### 範例 / Examples
+
+**不推薦 ❌ - 瀏覽器可讀取的 storage 保存敏感資料**:
+
+```typescript
+localStorage.setItem('access_token', accessToken)
+sessionStorage.setItem('refresh_token', refreshToken)
+localStorage.setItem('api_key', 'sk_live_xxx')
+```
+
+**推薦 ✅ - 前端只呼叫同源 API**:
+
+```typescript
+const response = await fetch('/api/account', {
+  credentials: 'include',
+})
+
+if (!response.ok) {
+  throw new Error('REQUEST_FAILED')
+}
+```
+
+**不推薦 ❌ - 把 private key 放進公開環境變數**:
+
+```typescript
+const apiKey = process.env.NEXT_PUBLIC_PRIVATE_API_KEY
+
+await fetch(`https://api.example.com/data?key=${apiKey}`)
+```
+
+**推薦 ✅ - secret 留在 server 端**:
+
+```typescript
+// Server-only code，只能在 server 端執行
+const apiKey = process.env.PRIVATE_API_KEY
+
+export async function fetchExternalData() {
+  const response = await fetch('https://api.example.com/data', {
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+    },
+  })
+
+  return response.json()
+}
+```
+
+### 常見陷阱 / Common Pitfalls
+
+**陷阱 1: 用 URL 傳 token**
+
+```typescript
+// ❌ URL 會進入瀏覽器歷史、server log、監控和截圖
+router.push(`/verify?token=${token}`)
+
+// ✅ 用 POST body 或一次性 server 流程
+await fetch('/api/verify', {
+  method: 'POST',
+  body: JSON.stringify({ token }),
+})
+```
+
+**陷阱 2: 開發 log 漏到正式環境**
+
+```typescript
+// ❌ response 可能包含 token 或個資
+console.log('response', response)
+
+// ✅ 只在開發環境輸出最小必要資訊
+if (process.env.NODE_ENV === 'development') {
+  console.debug('request failed', { status: response.status })
+}
+```
+
+### 參考現有實作 / Reference Implementation
+
+通用檢查位置：
+
+- `.gitignore` - `.env*` 應被忽略，`.env.example` 可保留公開範例。
+- `apps/frontend/package.json` - 確認沒有把 secret 透過 script 注入前端 build。
+- `apps/frontend/src/**/*.ts(x)` - 搜尋 `localStorage`、`sessionStorage`、`NEXT_PUBLIC`、`console.`。
+
+### 自動化 / Automation
+
+- **Git Hook**: ℹ️ 目前未設定 secret 掃描工具。
+- **Manual Review**: 搜尋 `NEXT_PUBLIC`、`localStorage`、`sessionStorage`、`console.log`、`api_key`、`token`。
+- **Optional Scanner**: 可視需求加入 secret 掃描工具；新增前需說明阻擋規則與誤報處理。
+- **Claude Hook**: ℹ️ 目前是準則提醒，不是 secret scanning。
+
+---
+
+## 準則 24: CORS（跨來源資源共享）與同源政策 / Guideline 24: CORS And Same-Origin Policy
+
+### 說明 / Description
+
+CORS 是瀏覽器同源政策下的跨來源讀取控制，不是 API 驗證、授權或 CSRF 防護。若前端只呼叫同源 API，通常不需要在前端專案新增 CORS 設定。若 Next.js Route Handler、proxy 或後端服務真的需要開放跨來源存取，正式環境必須使用明確允許清單（allowlist；常見說法是白名單），並搭配 `Vary: Origin`、credentials / cookie 規則和後端驗證。
+
+CORS controls cross-origin reads in browsers. It is not API authentication, authorization, or CSRF protection. If the frontend only calls same-origin APIs, the frontend project usually does not need CORS configuration. If a Next.js Route Handler, proxy, or backend service needs cross-origin access, production must use an explicit allowlist with `Vary: Origin`, credentials rules, and backend validation.
+
+### 為什麼重要 / Why This Matters
+
+- **錯誤安全感**：CORS 不會阻擋 curl、Postman、server-to-server request。
+- **Cookie 風險**：帶 cookie / credentials 的 request 需要更嚴格的 origin 與 CSRF 設計。
+- **部署可預測**：明確允許清單比開發期 wildcard 更容易審查和回滾。
+
+### Linus 哲學 / Linus Philosophy
+
+> "Do not add abstractions, frameworks, dependencies, or configuration until the current code shows a real need."
+
+If there is no cross-origin need, do not add CORS configuration. When there is a need, write the allowed origins and credentials rules as a small, reviewable boundary.
+
+### 檢查清單 / Checklist
+
+- [ ] 是否先確認真的需要跨來源存取？
+- [ ] 正式環境是否避免 `Access-Control-Allow-Origin: *` 搭配 credentials？
+- [ ] allowed origins 是否是明確的允許清單/白名單，而不是任意 regex 或 echo origin？
+- [ ] 使用 cookie 驗證時，是否另外處理 CSRF 風險？
+- [ ] CORS 設定是否放在 Route Handler、proxy 或後端邊界，而不是散落在 client 呼叫端？
+
+### 範例 / Examples
+
+**不推薦 ❌ - wildcard 搭配 credentials**:
+
+```typescript
+const headers = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Credentials': 'true',
+}
+```
+
+**推薦 ✅ - 明確允許清單**:
+
+```typescript
+const allowedOrigins = new Set(['https://app.example.com'])
+
+export function getCorsHeaders(origin: string | null) {
+  if (!origin || !allowedOrigins.has(origin)) {
+    return {}
+  }
+
+  return {
+    'Access-Control-Allow-Origin': origin,
+    'Access-Control-Allow-Credentials': 'true',
+    Vary: 'Origin',
+  }
+}
+```
+
+**推薦 ✅ - 同源呼叫不需要 CORS**:
+
+```typescript
+const response = await fetch('/api/profile', {
+  credentials: 'include',
+})
+```
+
+### 常見陷阱 / Common Pitfalls
+
+**陷阱 1: 誤把 CORS 當 API 保護**
+
+```typescript
+// ❌ CORS 不會替 API 做授權
+// Access-Control-Allow-Origin: https://app.example.com
+
+// ✅ API 仍要驗證身份、權限和輸入
+await requireAuthenticatedUser(request)
+await validateRequestBody(request)
+```
+
+**陷阱 2: 開發設定直接帶到正式環境**
+
+```typescript
+// ❌ 正式環境不應沿用寬鬆設定
+const allowedOrigin = '*'
+
+// ✅ 由環境設定明確來源，缺少時 fail closed
+const allowedOrigin = process.env.APP_ORIGIN
+if (!allowedOrigin) {
+  throw new Error('APP_ORIGIN_REQUIRED')
+}
+```
+
+### 參考現有實作 / Reference Implementation
+
+通用檢查位置：
+
+- `apps/frontend/next.config.ts` - 若新增 headers 或 image / remote 來源允許清單，範圍要明確。
+- `apps/frontend/src/app/**/route.ts` - 若新增 Route Handler，CORS、auth、輸入驗證應在此類邊界處理。
+- Client Component 中的 `fetch()` 不應用來補救後端 CORS 或授權設計。
+
+### 自動化 / Automation
+
+- **Manual Review**: 搜尋 `Access-Control-Allow-Origin`、`Access-Control-Allow-Credentials`、`headers()`。
+- **Integration Test**: 若有跨來源 API，測試允許與拒絕來源各一個案例。
+- **Git Hook**: ℹ️ 目前沒有 CORS / security headers 自動掃描。
+- **Claude Hook**: ℹ️ 目前是提醒腳本，不是 blocking check。
+
+---
+
+## 準則 25: 套件安全稽核 / Guideline 25: Dependency Security Audit
+
+### 說明 / Description
+
+新增套件前先確認它解決真問題，且沒有現有 API 或小型本地實作能更簡單地完成。套件安全更新要小而可審查：先看漏洞影響範圍、套件用途、lockfile 差異和 breaking changes，再更新。目前 workspace 使用 pnpm，因此安全稽核與 lockfile review 應以 `pnpm-lock.yaml` 和 `pnpm-workspace.yaml` 為準。
+
+Before adding a dependency, confirm it solves a real problem and cannot be replaced by an existing API or a small local implementation. Security updates should be small and reviewable: inspect the vulnerability scope, package usage, lockfile diff, and breaking changes before updating. The current workspace uses pnpm, so security audits and lockfile review should be based on `pnpm-lock.yaml` and `pnpm-workspace.yaml`.
+
+### 為什麼重要 / Why This Matters
+
+- **供應鏈風險**：每個套件都是新的維護與攻擊面。
+- **可審查性**：安全更新若混入大量無關升級，reviewer 很難判斷風險。
+- **可回滾性**：小範圍更新比較容易 bisect、rollback 和驗證。
+
+### Linus 哲學 / Linus Philosophy
+
+> "Prefer small, logical changes that can be understood and verified on their own."
+
+Dependency changes must be as reviewable as code patches. Do not hide the actual vulnerability fix inside a large bulk upgrade.
+
+### 檢查清單 / Checklist
+
+- [ ] 新套件是否有明確問題、替代方案與取捨？
+- [ ] 是否檢查套件維護狀態、下載量、授權與近期安全紀錄？
+- [ ] 是否用 `pnpm audit` 或同等工具檢查 high / critical 漏洞？
+- [ ] `pnpm-lock.yaml` diff 是否只包含本次必要變更？
+- [ ] 安全更新是否有對應驗證命令或 smoke test？
+
+### 範例 / Examples
+
+**不推薦 ❌ - 為小問題加入大型套件**:
+
+```typescript
+import leftPad from 'left-pad'
+
+export function formatCode(value: number) {
+  return leftPad(String(value), 4, '0')
+}
+```
+
+**推薦 ✅ - 用小型本地實作或標準 API**:
+
+```typescript
+export function formatCode(value: number) {
+  return String(value).padStart(4, '0')
+}
+```
+
+**推薦 ✅ - 用 pnpm 做安全稽核**:
+
+```bash
+pnpm audit --audit-level high
+pnpm outdated --recursive
+pnpm why <package-name>
+```
+
+### 常見陷阱 / Common Pitfalls
+
+**陷阱 1: 盲目更新所有套件**
+
+```bash
+# ❌ diff 太大，難以審查和回滾
+pnpm update --latest --recursive
+
+# ✅ 只更新受影響套件，並檢查 lockfile diff
+pnpm update <package-name>
+```
+
+**陷阱 2: 把 audit 結果全部當成同一級風險**
+
+```text
+// ❌ 不看影響範圍，只貼 audit output
+found vulnerabilities
+
+// ✅ 寫清楚是否在正式環境路徑、是否可觸發、如何修
+high severity: package-name
+impact: used by frontend production bundle
+fix: update package-name from x.y.z to x.y.z+1
+verification: pnpm audit --audit-level high; pnpm --filter frontend run type-check
+```
+
+### 參考現有實作 / Reference Implementation
+
+通用檢查位置：
+
+- `apps/frontend/package.json` - 前端套件與 script 的主要來源。
+- `package.json` - workspace、commit tooling 與 repo-level scripts。
+- `pnpm-workspace.yaml` - workspace package 範圍，避免審查漏掉新增 package。
+- `pnpm-lock.yaml` - 套件審查時必看 lockfile diff。
+
+### 自動化 / Automation
+
+- **pnpm audit**: ℹ️ 可手動執行 `pnpm audit --audit-level high`。
+- **Optional Monitoring**: 若新增套件監控工具，需在 README 記錄觸發條件與處理流程。
+- **Git Hook**: ℹ️ 目前 pre-commit 不執行套件安全稽核。
+- **Code Review**: ✅ 套件與 lockfile diff 必須人工審查。
+
+---
+
+## 總結 / Summary
+
+前端安全的 5 條準則核心思想：
+
+1. **準則 21**: 跨站腳本攻擊（XSS）防護 - 不可信資料預設渲染為純文字。
+2. **準則 22**: 輸入驗證 - 前端驗證是 UX，server/API 邊界才是安全。
+3. **準則 23**: 敏感資料處理 - secret 不進瀏覽器、URL 或 log。
+4. **準則 24**: CORS（跨來源資源共享）與同源政策 - 沒有跨來源需求就不加設定，有需求就明確允許清單。
+5. **準則 25**: 套件安全稽核 - 套件變更要小、可審查、可驗證。
+
+**Linus 哲學 / Linus Philosophy in Frontend Security**:
+
+- **Clear invariants** → 準則 21（不可信資料預設純文字）。
+- **Trust boundaries first** → 準則 22-24（安全決策放在 server/API 邊界）。
+- **Small reviewable patches** → 準則 25（套件更新不混入無關變更）。
+- **Pragmatism** → 全部準則（只為真實風險增加工具或配置）。
+
+---
+
+## 相關文檔 / Related Documents
+
+- [AGENTS.md](../../AGENTS.md) - Linus Torvalds 風格工程原則。
+- [README.md](README.md) - 準則總覽。
+- [template.md](template.md) - 準則文件格式模板。
+- [OWASP Top 10](https://owasp.org/www-project-top-ten/) - 常見 Web 安全風險。
+- [MDN: CORS](https://developer.mozilla.org/zh-TW/docs/Glossary/CORS) - 正體中文用語「跨來源資源共享」。
+- [MDN: 同源政策](https://developer.mozilla.org/zh-TW/docs/Web/Security/Defenses/Same-origin_policy) - 同源政策、CORS、CSRF 用語參考。
+- [MDN: 使用 HTTP Cookie](https://developer.mozilla.org/zh-TW/docs/Web/HTTP/Guides/Cookies) - `HttpOnly`、`Secure`、`SameSite` 與敏感訊息參考。
+- [MDN: Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) - CSP 參考。
+- [iThome: VMware NSX XSS 漏洞](https://www.ithome.com.tw/news/169446) - 台灣資安新聞用語「跨站腳本攻擊」「輸入驗證不當」。
+- [iThome: GlassWorm 供應鏈攻擊](https://www.ithome.com.tw/news/174484) - 台灣資安新聞用語「供應鏈攻擊」「套件」。
+- [Next.js Environment Variables](https://nextjs.org/docs/app/guides/environment-variables) - Next.js 環境變數行為。
+
+---
+
+**最後更新 / Last Updated**: 2026-05-14  
+**維護者 / Maintainer**: Frontend Team

--- a/.claude/rules/05-state-error-handling.md
+++ b/.claude/rules/05-state-error-handling.md
@@ -1,0 +1,789 @@
+---
+paths:
+  [
+    'apps/frontend/src/**/*.tsx',
+    'apps/frontend/src/**/*.ts',
+    'apps/frontend/package.json',
+    'apps/frontend/next.config.ts',
+  ]
+---
+
+# 狀態與錯誤處理 / State & Error Handling (準則 26-28)
+
+本文檔涵蓋 Next.js / React / TypeScript 前端的狀態與錯誤處理準則。重點是讓資料來源、錯誤邊界、使用者訊息與非同步 UI 狀態清楚可審查。
+
+This document covers state and error handling guidelines for Next.js / React / TypeScript frontends. The focus is to make state sources, error boundaries, user-facing messages, and async UI states clear and reviewable.
+
+---
+
+## 準則 26: 狀態來源與錯誤邊界 / Guideline 26: State Sources and Error Boundaries
+
+### 說明 / Description
+
+每個畫面都要能說清楚資料的唯一來源：remote/API data、URL、props、local component state，或是明確的 client-side store。可以推導出的資料不要重複存成 state。互動狀態留在最小 client component，跨頁或跨功能狀態才考慮集中管理。
+
+Remote/API state 不等於 client interaction state。來自 API、會被快取、會被背景重新抓取、或會被 mutation 影響的資料，導入後優先交給 TanStack Query 管理；表單輸入、dialog 開關、目前選取列、暫存篩選條件等互動狀態仍留在 React state 或 URL。
+
+錯誤也要分邊界。可預期錯誤，例如表單驗證失敗、API 回傳 400、查無資料，應該用 return value 或 component state 呈現。未捕捉例外才交給 Next.js `error.tsx` 或 `global-error.tsx` 形成 Error Boundary（錯誤邊界）。
+
+Every screen must have a clear source of truth: remote/API data, URL, props, local component state, or an explicit client-side store. Do not duplicate data that can be derived. Keep interaction state in the smallest client component, and only centralize state when it crosses page or feature boundaries.
+
+Remote/API state is not client interaction state. Data that comes from APIs, needs caching, may refetch in the background, or changes after mutations should use TanStack Query after it is introduced. Form input, dialog open state, selected rows, and temporary filters should remain in React state or the URL.
+
+Errors also need boundaries. Expected errors, such as form validation failures, API 400 responses, or empty data, should be represented as return values or component state. Uncaught exceptions belong in Next.js `error.tsx` or `global-error.tsx` Error Boundaries.
+
+### 為什麼重要 / Why This Matters
+
+- **資料流可審查**：reviewer 能看懂哪份資料是真的，不需要追多份 state。
+- **Remote/API state 有一致生命週期**：快取、重新抓取、失效與 mutation 不散落在 component。
+- **錯誤隔離清楚**：局部 render crash 不會讓整個 app 白畫面。
+- **使用者體驗穩定**：可預期錯誤用明確訊息處理，不把使用者丟進系統錯誤頁。
+- **維護成本更低**：狀態與錯誤邊界固定，後續工程師不用猜特殊情況。
+
+### Linus 哲學 / Linus Philosophy
+
+> "Design the data model and boundaries first."
+
+The core of state and error handling is not adding another tool — it is drawing the boundaries correctly. The simpler the data sources, the more errors can be isolated, and the fewer special branches the code needs.
+
+### 檢查清單 / Checklist
+
+- [ ] 這個畫面的資料來源是否明確，沒有把可推導資料重複存成 state？
+- [ ] Remote/API state 是否使用 TanStack Query（導入後），而不是手寫分散的 `useEffect` fetch？
+- [ ] `'use client'` 是否只放在需要 hooks、事件或瀏覽器 API 的最小邊界？
+- [ ] 可預期錯誤是否用 return value、state 或 inline message 表示，而不是丟給 Error Boundary？
+- [ ] route segment 是否在有實際風險時提供 `error.tsx`，root layout 風險才使用 `global-error.tsx`？
+- [ ] 對使用者顯示的錯誤訊息是否避免 stack trace、內部代碼與敏感資訊？
+- [ ] 錯誤紀錄是否集中在可替換的 adapter 或服務邊界，而不是散落 `console.error`？
+
+### 範例 / Examples
+
+**不推薦 ❌ - 重複保存可推導狀態，讓資料來源變多**:
+
+```tsx
+'use client'
+
+function RecordList({ records }: { records: RecordItem[] }) {
+  const [query, setQuery] = useState('')
+  const [filteredRecords, setFilteredRecords] = useState(records)
+  const [totalCount, setTotalCount] = useState(records.length)
+
+  useEffect(() => {
+    const nextRecords = records.filter((record) => record.name.includes(query))
+    setFilteredRecords(nextRecords)
+    setTotalCount(nextRecords.length)
+  }, [records, query])
+
+  return <RecordTable records={filteredRecords} totalCount={totalCount} />
+}
+```
+
+**推薦 ✅ - 保留單一來源，可推導資料直接推導**:
+
+```tsx
+'use client'
+
+function RecordList({ records }: { records: RecordItem[] }) {
+  const [query, setQuery] = useState('')
+
+  const filteredRecords = records.filter((record) =>
+    record.name.includes(query)
+  )
+
+  return (
+    <>
+      <SearchInput value={query} onValueChange={setQuery} />
+      <RecordTable
+        records={filteredRecords}
+        totalCount={filteredRecords.length}
+      />
+    </>
+  )
+}
+```
+
+**推薦 ✅ - route segment 用 Error Boundary 隔離未捕捉例外**:
+
+```tsx
+// app/(dashboard)/records/error.tsx
+'use client'
+
+import { useEffect } from 'react'
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  useEffect(() => {
+    reportError(error)
+  }, [error])
+
+  return (
+    <section className="space-y-3 p-6">
+      <h2 className="text-lg font-semibold">資料暫時無法顯示</h2>
+      <p className="text-sm text-muted-foreground">請重新整理，或稍後再試。</p>
+      <button type="button" onClick={reset}>
+        重試
+      </button>
+    </section>
+  )
+}
+```
+
+### 常見陷阱 / Common Pitfalls
+
+**陷阱 1: 以為 Error Boundary 會處理所有錯誤**
+
+```tsx
+// ❌ event handler 的錯誤不會自動被 error.tsx 接住
+function SaveButton() {
+  const handleClick = async () => {
+    await saveRecord()
+    throw new Error('Save failed')
+  }
+
+  return <button onClick={handleClick}>儲存</button>
+}
+
+// ✅ 可預期的互動錯誤要在 handler 中轉成 UI state
+function SaveButton() {
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+
+  const handleClick = async () => {
+    setErrorMessage(null)
+    const result = await saveRecord()
+
+    if (!result.ok) {
+      setErrorMessage('儲存失敗，請稍後再試')
+    }
+  }
+
+  return (
+    <>
+      <button onClick={handleClick}>儲存</button>
+      {errorMessage && (
+        <p className="text-sm text-destructive">{errorMessage}</p>
+      )}
+    </>
+  )
+}
+```
+
+**陷阱 2: 用全域 handler 掩蓋局部資料問題**
+
+```typescript
+// ❌ 所有 API 失敗都丟同一個 toast，使用者不知道哪裡壞了
+async function loadRecords() {
+  try {
+    return await fetchRecords()
+  } catch {
+    toast.error('系統發生錯誤')
+    return []
+  }
+}
+
+// ✅ 在資料邊界保留可診斷狀態
+async function loadRecords(): Promise<RecordLoadResult> {
+  const response = await fetch('/api/records')
+
+  if (response.status === 404) {
+    return { status: 'empty' }
+  }
+
+  if (!response.ok) {
+    return { status: 'error', message: '資料讀取失敗，請稍後再試' }
+  }
+
+  return { status: 'success', records: await response.json() }
+}
+```
+
+### 參考現有實作 / Reference Implementation
+
+通用檢查位置：
+
+- `apps/frontend/src/app/**/*.tsx` - route、page、client component 的 state 邊界。
+- `apps/frontend/src/app/layout.tsx` - 全域 layout 與 toast provider 的放置位置。
+- `apps/frontend/src/app/components/atoms/sonner.tsx` - toast 呈現層；不應承擔資料分類責任。
+
+目前沒有確認存在的 `error.tsx`、`global-error.tsx` 或集中 API client。新增前應先說清楚真實錯誤路徑與最小範圍，不要為了「看起來完整」先加空架構。
+
+TanStack Query 導入後，應能找到單一 `QueryClientProvider` 設定、穩定的 query key 命名方式，以及靠近資料邊界的 query / mutation hook。不要在多個 component 各自建立 `QueryClient`。
+
+### 自動化 / Automation
+
+- **ESLint**: `next/core-web-vitals`、`next/typescript` 可檢查部分 React / Next.js 問題。
+- **Type Check**: `pnpm --filter frontend run type-check`
+- **Git Hook**: `.husky/pre-commit` 會執行 type-check 與 staged lint/format。
+- **Manual Review**: 檢查 state source、`'use client'` 邊界、Error Boundary 粒度與錯誤訊息內容。
+- **Claude Hook**: `check-guidelines.sh` 是提醒腳本，不是完整 blocking check。
+
+---
+
+## 準則 27: 可預期錯誤與使用者訊息 / Guideline 27: Expected Errors and User-Facing Messages
+
+### 說明 / Description
+
+可預期錯誤是正常流程的一部分，例如欄位格式錯誤、權限不足、請求失敗、資料不存在。這些錯誤不要用未捕捉例外處理；要用 typed result、form state、inline error、toast 或空狀態清楚呈現。
+
+錯誤訊息要站在使用者視角：發生什麼事、能不能重試、需要修正哪個欄位。技術細節、stack trace、內部錯誤碼與敏感資料只應進入紀錄或監控。若 API 有穩定 error code，請在 API adapter 或 helper 集中轉成可顯示訊息；若專案沒有多語系基礎建設，不要把不存在的 locale 目錄或檢查腳本寫成強制規則。
+
+Expected errors are part of normal flow, such as invalid fields, insufficient permissions, failed requests, or missing data. Do not handle these as uncaught exceptions. Represent them with typed results, form state, inline errors, toasts, or empty states.
+
+User-facing messages should explain what happened, whether retry is possible, and which field needs attention. Technical details, stack traces, internal error codes, and sensitive data belong in logs or monitoring only. If the API has stable error codes, map them to displayable messages in one API adapter or helper. If the project has no localization infrastructure, do not document non-existent locale folders or scripts as mandatory.
+
+### 為什麼重要 / Why This Matters
+
+- **使用者能修正問題**：欄位錯誤要出現在欄位附近，不只是一個泛用 toast。
+- **錯誤分類穩定**：可預期錯誤不污染系統錯誤監控。
+- **安全性較好**：不把內部錯誤、stack trace 或敏感資訊顯示到瀏覽器。
+- **維護更便宜**：錯誤訊息集中映射，新增錯誤碼時 reviewer 有地方檢查。
+
+### Linus 哲學 / Linus Philosophy
+
+> "Solve a real problem."
+
+Error messages are not a translation exercise. The real problem to solve is letting users know their next step, letting engineers know what went wrong, and making sure neither leaks information the other should not see.
+
+### 檢查清單 / Checklist
+
+- [ ] 可預期錯誤是否以 typed result、state 或 form action result 表示？
+- [ ] 欄位錯誤是否顯示在欄位附近，並可被輔助科技讀到？
+- [ ] 全頁或全區塊錯誤是否提供可行下一步，例如重試、返回或重新輸入？
+- [ ] 使用者訊息是否避免 `error.message`、stack trace、SQL/API 內部細節與敏感資料？
+- [ ] API error code 是否在單一 helper 或 adapter 轉成穩定訊息？
+- [ ] 文件是否沒有要求目前專案不存在的語系目錄、監控服務設定或檢查腳本？
+
+### 範例 / Examples
+
+**不推薦 ❌ - 將表單驗證丟成系統錯誤**:
+
+```tsx
+async function handleSubmit(formData: FormData) {
+  try {
+    await submitForm(formData)
+    toast.success('已儲存')
+  } catch (error) {
+    toast.error(String(error))
+  }
+}
+```
+
+**推薦 ✅ - 可預期錯誤回傳成表單狀態**:
+
+```tsx
+type FormState = {
+  message?: string
+  fieldErrors?: {
+    name?: string
+    email?: string
+  }
+}
+
+async function submitForm(
+  _prevState: FormState,
+  formData: FormData
+): Promise<FormState> {
+  const name = String(formData.get('name') ?? '').trim()
+  const email = String(formData.get('email') ?? '').trim()
+  const fieldErrors: FormState['fieldErrors'] = {}
+
+  if (!name) fieldErrors.name = '請輸入名稱'
+  if (!email.includes('@')) fieldErrors.email = '請輸入有效的電子郵件'
+
+  if (Object.keys(fieldErrors).length > 0) {
+    return { fieldErrors }
+  }
+
+  const result = await saveForm({ name, email })
+
+  if (!result.ok) {
+    return { message: '儲存失敗，請稍後再試' }
+  }
+
+  return {}
+}
+```
+
+```tsx
+'use client'
+
+import { useActionState } from 'react'
+
+const initialState: FormState = {}
+
+function ContactForm() {
+  const [state, formAction, pending] = useActionState(submitForm, initialState)
+
+  return (
+    <form action={formAction} className="space-y-4">
+      <Field name="name" label="名稱" errorMessage={state.fieldErrors?.name} />
+      <Field
+        name="email"
+        label="電子郵件"
+        errorMessage={state.fieldErrors?.email}
+      />
+      {state.message && (
+        <p role="alert" className="text-sm text-destructive">
+          {state.message}
+        </p>
+      )}
+      <button type="submit" disabled={pending}>
+        {pending ? '送出中' : '送出'}
+      </button>
+    </form>
+  )
+}
+```
+
+**推薦 ✅ - 集中轉換 API error code，不硬綁不存在的語系目錄**:
+
+```typescript
+const ERROR_MESSAGE_BY_CODE: Record<string, string> = {
+  VALIDATION_FAILED: '資料格式不正確，請檢查後再送出',
+  PERMISSION_DENIED: '您沒有權限執行此操作',
+  RATE_LIMITED: '操作太頻繁，請稍後再試',
+}
+
+export function getUserMessageFromApiError(error: ApiError): string {
+  return ERROR_MESSAGE_BY_CODE[error.code] ?? '操作失敗，請稍後再試'
+}
+```
+
+### 常見陷阱 / Common Pitfalls
+
+**陷阱 1: 直接顯示 API 原始錯誤**
+
+```typescript
+// ❌ 可能洩漏技術細節，也可能不是使用者語言
+toast.error(error.message)
+
+// ✅ 先分類，再顯示穩定訊息
+toast.error(getUserMessage(error))
+```
+
+**陷阱 2: 空 catch 讓錯誤消失**
+
+```typescript
+// ❌ 使用者沒有回饋，工程師也沒有診斷線索
+try {
+  await saveChanges()
+} catch {
+  // ignored
+}
+
+// ✅ 至少轉成 UI state 或重新拋給上層邊界
+try {
+  await saveChanges()
+} catch (error) {
+  setErrorMessage('儲存失敗，請稍後再試')
+  reportError(error)
+}
+```
+
+**陷阱 3: 把不存在的語系機制寫成標準**
+
+```markdown
+<!-- ❌ 專案沒有語系檔，文件卻要求 pre-commit 必跑 -->
+
+- Git Hook 必須檢查所有錯誤訊息翻譯
+
+<!-- ✅ 先描述穩定問題，再依實際工具落地 -->
+
+- 若導入多語系，error code 對應表必須和語系檔一起 review。
+```
+
+### 參考現有實作 / Reference Implementation
+
+通用檢查位置：
+
+- `apps/frontend/src/app/components/atoms/sonner.tsx` - toast 視覺呈現層。
+- `apps/frontend/src/app/**/*.tsx` - 表單、button handler、dialog 與 route-level error UI。
+- `apps/frontend/package.json` - 目前未列出語系、監控、集中 API client 或資料 fetching 工具；文件不得把未啟用工具描述成既有強制標準。
+
+### 自動化 / Automation
+
+- **ESLint**: `no-empty` 可避免空區塊，但無法判斷錯誤訊息是否友善。
+- **Type Check**: typed result 與 `unknown` error narrowing 可由 TypeScript 協助。
+- **Git Hook**: 目前沒有錯誤訊息翻譯專用 blocking check。
+- **Manual Review**: 檢查可預期錯誤是否回到 UI state，錯誤訊息是否安全、可理解、可操作。
+
+---
+
+## 準則 28: Loading、Empty 和 Error State / Guideline 28: Loading, Empty, and Error State
+
+### 說明 / Description
+
+每個非同步流程都應該明確處理 loading、success、empty、error 狀態。route segment 的慢路徑可用 Next.js `loading.tsx`；元件內局部慢路徑可用 React `<Suspense>`；表單提交可用 `useActionState` 或 `useFormStatus` 的 `pending`；一般 client-side async handler 可用 `useState` 管理。
+
+TanStack Query 導入後，API 查詢優先使用 `useQuery` 的 `isPending`、`isError`、`isSuccess` 與 `isFetching` 表達狀態；寫入操作使用 `useMutation`，並在成功後 invalidate 相關 query。`queryKey` 必須穩定、可序列化，且包含會影響資料內容的參數。
+
+Every async flow should explicitly handle loading, success, empty, and error states. Slow route segments can use Next.js `loading.tsx`; local slow subtrees can use React `<Suspense>`; form submissions can use `useActionState` or `useFormStatus` `pending`; general client-side async handlers can use `useState`.
+
+After TanStack Query is introduced, API reads should use `useQuery` states such as `isPending`, `isError`, `isSuccess`, and `isFetching`. Writes should use `useMutation` and invalidate related queries on success. `queryKey` values must be stable, serializable, and include parameters that affect the data.
+
+### 為什麼重要 / Why This Matters
+
+- **避免白畫面**：使用者能看出系統正在處理，而不是以為壞掉。
+- **避免重複操作**：送出中要 disable 相關操作，減少重複請求。
+- **空狀態清楚**：沒有資料不是錯誤，應該用 empty state 表示。
+- **併發更安全**：慢請求、重試與切換條件時，UI 不會被舊結果覆蓋。
+
+### Linus 哲學 / Linus Philosophy
+
+> "Fast feedback is a feature."
+
+Loading, empty, and error states are fast feedback for the user. The good approach is usually small: an explicit state model, an appropriate fallback UI, and a verifiable retry or disable behavior.
+
+### 檢查清單 / Checklist
+
+- [ ] 非同步流程是否有 loading、success、empty、error 狀態？
+- [ ] TanStack Query 的 `queryKey` 是否穩定、可序列化，並包含必要參數？
+- [ ] `queryFn` 使用 `fetch` 時，是否在 `response.ok === false` 時 throw，讓 query 進入 error state？
+- [ ] mutation 成功後是否 invalidate 或更新相關 query，避免畫面停在舊資料？
+- [ ] `staleTime`、retry、background refetch 是否依資料新鮮度需求明確設定或接受預設？
+- [ ] route-level 慢頁面是否需要 `loading.tsx` 或 `<Suspense>` fallback？
+- [ ] 表單或按鈕送出中是否 disable 相關操作，並顯示 pending 狀態？
+- [ ] empty state 是否和 error state 分開，不把「沒有資料」當成失敗？
+- [ ] 錯誤狀態是否提供可行動作，例如重試、返回、重新輸入？
+- [ ] 多個並行請求是否避免共用單一 boolean 造成狀態互相覆蓋？
+
+### 範例 / Examples
+
+**不推薦 ❌ - 非同步操作沒有任何回饋**:
+
+```tsx
+function SaveButton() {
+  const handleClick = async () => {
+    await saveChanges()
+    toast.success('已儲存')
+  }
+
+  return <button onClick={handleClick}>儲存</button>
+}
+```
+
+**推薦 ✅ - client-side async handler 有 pending 與 error state**:
+
+```tsx
+'use client'
+
+function SaveButton() {
+  const [status, setStatus] = useState<'idle' | 'pending' | 'error'>('idle')
+
+  const handleClick = async () => {
+    setStatus('pending')
+
+    try {
+      const result = await saveChanges()
+
+      if (!result.ok) {
+        setStatus('error')
+        return
+      }
+
+      setStatus('idle')
+      toast.success('已儲存')
+    } catch (error) {
+      reportError(error)
+      setStatus('error')
+    }
+  }
+
+  return (
+    <>
+      <button onClick={handleClick} disabled={status === 'pending'}>
+        {status === 'pending' ? '儲存中' : '儲存'}
+      </button>
+      {status === 'error' && (
+        <p role="alert" className="text-sm text-destructive">
+          儲存失敗，請稍後再試。
+        </p>
+      )}
+    </>
+  )
+}
+```
+
+**推薦 ✅ - route-level loading 用 `loading.tsx` 或 Skeleton**:
+
+```tsx
+// app/(dashboard)/records/loading.tsx
+import { Skeleton } from '@/app/components/atoms'
+
+export default function Loading() {
+  return (
+    <section className="space-y-3 p-6">
+      <Skeleton className="h-8 w-48" />
+      <Skeleton className="h-64 w-full" />
+    </section>
+  )
+}
+```
+
+**推薦 ✅ - 明確分開 loading、empty、error、success**:
+
+```tsx
+type AsyncState<T> =
+  | { status: 'loading' }
+  | { status: 'empty' }
+  | { status: 'error'; message: string }
+  | { status: 'success'; data: T }
+
+function RecordPanel({ state }: { state: AsyncState<RecordItem[]> }) {
+  switch (state.status) {
+    case 'loading':
+      return <RecordSkeleton />
+    case 'empty':
+      return <EmptyState title="目前沒有資料" />
+    case 'error':
+      return <ErrorState message={state.message} />
+    case 'success':
+      return <RecordTable records={state.data} />
+  }
+}
+```
+
+**推薦 ✅ - TanStack Query 管理 remote/API state**:
+
+```tsx
+'use client'
+
+import { useQuery } from '@tanstack/react-query'
+
+const recordKeys = {
+  all: ['records'] as const,
+  list: (filters: RecordFilters) =>
+    [...recordKeys.all, 'list', filters] as const,
+}
+
+async function fetchRecords(
+  filters: RecordFilters,
+  signal: AbortSignal
+): Promise<RecordItem[]> {
+  const searchParams = new URLSearchParams({
+    keyword: filters.keyword,
+    status: filters.status,
+  })
+  const response = await fetch(`/api/records?${searchParams}`, { signal })
+
+  if (!response.ok) {
+    throw new Error('Failed to fetch records')
+  }
+
+  return response.json()
+}
+
+function RecordQueryPanel({ filters }: { filters: RecordFilters }) {
+  const { data, isPending, isError, error, isFetching } = useQuery({
+    queryKey: recordKeys.list(filters),
+    queryFn: ({ signal }) => fetchRecords(filters, signal),
+    staleTime: 60 * 1000,
+  })
+
+  if (isPending) return <RecordSkeleton />
+
+  if (isError) {
+    return <ErrorState message={getUserMessage(error)} />
+  }
+
+  if (data.length === 0) {
+    return <EmptyState title="目前沒有資料" />
+  }
+
+  return <RecordTable records={data} isRefreshing={isFetching} />
+}
+```
+
+**推薦 ✅ - mutation 成功後 invalidate 相關 query**:
+
+```tsx
+'use client'
+
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+function UpdateRecordButton({ record }: { record: RecordItem }) {
+  const queryClient = useQueryClient()
+  const mutation = useMutation({
+    mutationFn: updateRecord,
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: recordKeys.all })
+    },
+  })
+
+  return (
+    <button
+      type="button"
+      disabled={mutation.isPending}
+      onClick={() => mutation.mutate(record)}
+    >
+      {mutation.isPending ? '更新中' : '更新'}
+    </button>
+  )
+}
+```
+
+**推薦 ✅ - form submit 使用 `useFormStatus` 的 pending**:
+
+```tsx
+'use client'
+
+import { useFormStatus } from 'react-dom'
+
+function SubmitButton() {
+  const { pending } = useFormStatus()
+
+  return (
+    <button type="submit" disabled={pending}>
+      {pending ? '送出中' : '送出'}
+    </button>
+  )
+}
+```
+
+### 常見陷阱 / Common Pitfalls
+
+**陷阱 1: 忘記在失敗路徑重置 loading**
+
+```typescript
+// ❌ saveChanges 失敗後可能永遠停在 loading
+setIsLoading(true)
+await saveChanges()
+setIsLoading(false)
+
+// ✅ finally 保證重置
+setIsLoading(true)
+try {
+  await saveChanges()
+} finally {
+  setIsLoading(false)
+}
+```
+
+**陷阱 2: 多個請求共用一個 loading boolean**
+
+```typescript
+// ❌ A 完成時會把 B 的 loading 也關掉
+const [isLoading, setIsLoading] = useState(false)
+
+async function loadA() {
+  setIsLoading(true)
+  await fetchA()
+  setIsLoading(false)
+}
+
+async function loadB() {
+  setIsLoading(true)
+  await fetchB()
+  setIsLoading(false)
+}
+
+// ✅ 分開狀態，或用明確的 request key / async state
+const [loadingByKey, setLoadingByKey] = useState<Record<string, boolean>>({})
+```
+
+**陷阱 3: 只有 spinner，沒有內容結構**
+
+```tsx
+// ❌ 大區塊只顯示 spinner，使用者不知道什麼正在載入
+return <Spinner />
+
+// ✅ 大區塊用 Skeleton 或保留已知 layout
+return <RecordSkeleton />
+```
+
+**陷阱 4: query key 沒有包含影響資料的參數**
+
+```tsx
+// ❌ filters 改變時仍共用同一份 cache
+useQuery({
+  queryKey: ['records'],
+  queryFn: () => fetchRecords(filters),
+})
+
+// ✅ query key 描述資料本身
+useQuery({
+  queryKey: ['records', 'list', filters],
+  queryFn: () => fetchRecords(filters),
+})
+```
+
+**陷阱 5: fetch 失敗但沒有 throw**
+
+```typescript
+// ❌ fetch 不會因 HTTP 400/500 自動 throw
+async function fetchRecords() {
+  const response = await fetch('/api/records')
+  return response.json()
+}
+
+// ✅ 明確丟出錯誤，TanStack Query 才會進入 isError
+async function fetchRecords() {
+  const response = await fetch('/api/records')
+
+  if (!response.ok) {
+    throw new Error('Failed to fetch records')
+  }
+
+  return response.json()
+}
+```
+
+### 參考現有實作 / Reference Implementation
+
+通用檢查位置：
+
+- `apps/frontend/src/app/components/atoms/skeleton.tsx` - Skeleton 基礎元件。
+- `apps/frontend/src/app/components/atoms/sonner.tsx` - 操作結果或非欄位錯誤的 toast 呈現。
+- `apps/frontend/src/app/**/*.tsx` - page、form、dialog、table、chart 等非同步或互動入口。
+- TanStack Query 導入後，檢查 `QueryClientProvider`、query key factory、query hook 與 mutation hook 是否集中在清楚資料邊界。
+
+### 自動化 / Automation
+
+- **ESLint**: Hooks 規則可檢查部分 dependency 與 hooks 使用方式。
+- **TanStack Query Devtools**: 導入後可在開發環境觀察 cache、stale、fetching 與 invalidation 行為。
+- **Type Check**: discriminated union 可讓 TypeScript 檢查狀態分支是否完整。
+- **Build Check**: `pnpm --filter frontend run build` 可驗證 Next.js special files 與 route 結構。
+- **Manual Review**: 檢查 loading、empty、error、success 分支、query key、`staleTime`、mutation invalidation 與重試/disable 行為。
+
+---
+
+## 總結 / Summary
+
+狀態與錯誤處理的 3 條準則核心思想：
+
+1. **準則 26**: 狀態來源與錯誤邊界要明確，remote/API state 導入後交給 TanStack Query，避免重複 state 和錯誤特殊情況。
+2. **準則 27**: 可預期錯誤是 UI 狀態，不是系統 crash；使用者訊息要可操作且不洩漏內部細節。
+3. **準則 28**: 非同步流程要有 loading、empty、error、success 狀態，API 查詢與 mutation 導入後依 TanStack Query 的狀態模型落地。
+
+**Linus 哲學 / Linus Philosophy in State & Error Handling**:
+
+- **Good Taste** → 準則 26（清楚邊界消除特殊情況）
+- **Never Break Userspace** → 準則 27（錯誤訊息不能把使用者丟進技術細節）
+- **Fast Feedback** → 準則 28（每個慢路徑都有可見回饋）
+
+---
+
+## 相關文檔 / Related Documents
+
+- [AGENTS.md](../../AGENTS.md) - Linus Torvalds 風格工程原則。
+- [README.md](README.md) - 準則總覽。
+- [03-frontend-performance.md](03-frontend-performance.md) - Client boundary、lazy loading 與效能狀態。
+- [04-frontend-security.md](04-frontend-security.md) - 錯誤訊息與資料信任邊界。
+- [09-typescript.md](09-typescript.md) - TypeScript 狀態模型與型別規則。
+- [Next.js Error Handling](https://nextjs.org/docs/15/app/getting-started/error-handling) - App Router error handling。
+- [Next.js loading.js](https://nextjs.org/docs/app/api-reference/file-conventions/loading) - route-level loading UI。
+- [React Suspense](https://react.dev/reference/react/Suspense) - fallback UI 與 Suspense boundary。
+- [React form pending state](https://react.dev/reference/react-dom/components/form) - `useFormStatus` 與 pending state。
+- [TanStack Query Queries](https://tanstack.com/query/v5/docs/framework/react/guides/queries) - `useQuery` 狀態模型。
+- [TanStack Query Query Keys](https://tanstack.com/query/latest/docs/framework/react/guides/query-keys) - query key 命名與 cache 邊界。
+- [TanStack Query Invalidations from Mutations](https://tanstack.com/query/latest/docs/framework/react/guides/invalidations-from-mutations) - mutation 後的 query invalidation。
+- [TanStack Query Important Defaults](https://tanstack.com/query/latest/docs/framework/react/guides/important-defaults) - stale、retry、gcTime 與 background refetch 預設。
+
+---
+
+**最後更新 / Last Updated**: 2026-05-16  
+**維護者 / Maintainer**: Frontend Team

--- a/.claude/rules/06-collaboration.md
+++ b/.claude/rules/06-collaboration.md
@@ -1,0 +1,500 @@
+---
+paths: ['**/*.md', 'apps/frontend/src/**/*.ts', 'apps/frontend/src/**/*.tsx']
+---
+
+# 協作與溝通 / Collaboration & Communication (準則 29-31)
+
+本文檔涵蓋 API 契約、Pull Request Review 與 Commit message 規範。目標不是增加流程，而是讓每次變更都能被快速理解、可靠驗證、必要時容易回溯。
+
+This document covers API contracts, Pull Request review, and commit message standards. The goal is not more process, but changes that are easy to understand, verify, and trace.
+
+---
+
+## 準則 29: API 契約與型別同步 / Guideline 29: API Contract & Type Sync
+
+### 說明 / Description
+
+前端與 API provider 之間必須有清楚契約。Request、response、error shape、nullable 欄位、分頁、排序、狀態碼與權限行為，都要能從文件或型別看出來。前端 TypeScript 型別不能靠猜，也不能用 `any` 把 API 變更藏到執行期才失敗。
+
+Frontend code and API providers must have a clear contract. Request, response, error shape, nullable fields, pagination, sorting, status codes, and authorization behavior must be visible through documentation or types. Frontend TypeScript types must not be guessed or hidden behind `any`.
+
+適用範圍：
+
+- 新增或修改 API endpoint。
+- 修改 response 欄位、命名、nullable 規則或錯誤格式。
+- 前端新增 API adapter、client-side data fetcher 或資料轉換層。
+- 串接既有或外部 API，並需要同步 OpenAPI、Swagger、API 文件或團隊約定。
+
+### 為什麼重要 / Why This Matters
+
+- **避免執行期錯誤**：契約不清楚時，欄位改名、`null`、錯誤格式變更會直接進到 UI。
+- **降低溝通成本**：reviewer 不需要靠聊天記錄還原 API 行為。
+- **維持資料邊界**：API response 命名與前端命名可以不同，但轉換必須集中在 adapter。
+- **方便回溯**：API 破壞性變更要能從 PR、commit 與文件追到原因。
+
+### Linus 哲學 / Linus Philosophy
+
+> "Bad programmers worry about the code. Good programmers worry about data structures."
+
+API contract 是跨系統的資料結構。先把資料形狀講清楚，實作才不需要用一堆特殊情況補洞。Good taste 在這裡不是多加工具，而是讓資料邊界簡單、明確、可檢查。
+
+### 檢查清單 / Checklist
+
+- [ ] API 文件是否更新，且和實際 request/response 一致？
+- [ ] TypeScript interface 是否明確描述 nullable、optional、enum 與錯誤格式？
+- [ ] API response 的 `snake_case` 與前端 `camelCase` 是否只在 adapter 邊界轉換？
+- [ ] 是否避免在 API 層、shared type 或 UI props 使用 `any`？
+- [ ] 破壞性變更是否寫在 PR 與 commit body，並說明遷移方式？
+- [ ] 若目前沒有自動產生型別，是否至少用人工 review 比對 API 文件與前端型別？
+
+### 範例 / Examples
+
+**不推薦 - 前端直接相信未知 response**:
+
+```typescript
+export async function getUser(id: string) {
+  const response = await fetch(`/api/users/${id}`)
+  return response.json()
+}
+
+const user = await getUser(userId)
+console.log(user.created_at.toLocaleDateString())
+```
+
+問題是呼叫端不知道 `created_at` 是字串、`Date`、`null`，也不知道失敗時 response 長什麼樣子。
+
+**推薦 - 在 API adapter 定義契約與轉換**:
+
+```typescript
+interface UserResponse {
+  id: string
+  display_name: string
+  created_at: string
+  deleted_at: string | null
+}
+
+export interface User {
+  id: string
+  displayName: string
+  createdAt: string
+  deletedAt: string | null
+}
+
+function mapUser(response: UserResponse): User {
+  return {
+    id: response.id,
+    displayName: response.display_name,
+    createdAt: response.created_at,
+    deletedAt: response.deleted_at,
+  }
+}
+
+export async function getUser(id: string): Promise<User> {
+  const response = await fetch(`/api/users/${id}`)
+
+  if (!response.ok) {
+    throw new Error(`Failed to load user: ${response.status}`)
+  }
+
+  const data = (await response.json()) as UserResponse
+  return mapUser(data)
+}
+```
+
+**推薦 - 明確表示 API 錯誤格式**:
+
+```typescript
+interface ApiErrorResponse {
+  code: string
+  message: string
+  fieldErrors?: Record<string, string[]>
+}
+
+export class ApiError extends Error {
+  constructor(
+    readonly status: number,
+    readonly body: ApiErrorResponse
+  ) {
+    super(body.message)
+  }
+}
+```
+
+### 常見陷阱 / Common Pitfalls
+
+**陷阱 1: 欄位命名到處轉換**
+
+```typescript
+// 不推薦：UI component 知道 API response 欄位命名
+function UserName({ user }: { user: UserResponse }) {
+  return <span>{user.display_name}</span>
+}
+
+// 推薦：API response 格式留在 adapter，UI 使用前端語意
+function UserName({ user }: { user: User }) {
+  return <span>{user.displayName}</span>
+}
+```
+
+**陷阱 2: 用 optional 逃避 nullable 契約**
+
+```typescript
+// 不推薦：不知道欄位是不存在，還是明確為 null
+interface User {
+  deletedAt?: string
+}
+
+// 推薦：契約說清楚
+interface User {
+  deletedAt: string | null
+}
+```
+
+**陷阱 3: API 文件更新但前端型別沒有同步**
+
+```markdown
+不推薦：
+
+- API provider 改 response
+- 前端 PR 之後才發現欄位壞掉
+
+推薦：
+
+- 同一個 PR 或同一組 PR 說清楚 API 變更
+- 文件、API 契約、前端型別一起 review
+- 不能同時上線時，先提供向後相容欄位
+```
+
+### 參考現有實作 / Reference Implementation
+
+專案中可參考的穩定位置：
+
+- `apps/frontend/src/app/types/` - 前端共享型別放置位置。
+- `apps/frontend/src/app/lib/` - 前端工具與資料轉換邏輯放置位置。
+
+### 自動化 / Automation
+
+- **API 文件提醒**: 若串接的 API 有 OpenAPI / Swagger / 文件約定，PR 必須人工比對契約是否同步；目前不要把它寫成 blocking automation。
+- **TypeScript**: `pnpm --filter frontend run type-check` 可檢查前端型別使用。
+- **ESLint**: `pnpm --filter frontend run lint` 可抓出部分 unsafe 或未使用程式碼。
+- **Git Hook**: Husky pre-commit 會執行前端 type-check 與 lint-staged。
+- **Claude Hook**: `.claude/hooks/check-guidelines.sh` 是提醒腳本，不是完整 blocking check。
+
+---
+
+## 準則 30: Code Review 規範 / Guideline 30: Code Review Standards
+
+### 說明 / Description
+
+Pull Request 要讓 reviewer 快速回答四件事：這次解決什麼問題、為什麼用這個做法、如何驗證、還剩什麼風險。Review 的重點是正確性、資料流、可維護性與使用者影響，不是把個人口味包裝成規則。
+
+Pull Requests should help reviewers answer four questions quickly: what problem is solved, why this shape, how it was verified, and what risk remains. Review should focus on correctness, data flow, maintainability, and user impact, not personal taste disguised as rules.
+
+適用範圍：
+
+- 所有功能、修 bug、重構、文件與設定變更。
+- UI 變更、API contract 變更、跨模組資料流變更。
+- 需要其他工程師理解、驗證或接手維護的修改。
+
+### 為什麼重要 / Why This Matters
+
+- **Review 才有效率**：好的 PR 描述會把 reviewer 的時間花在風險上，而不是猜背景。
+- **降低合併風險**：小而完整的 PR 比大型混合 PR 更容易驗證。
+- **保留決策脈絡**：半年後看 PR，仍能理解當時為什麼這樣改。
+- **避免形式主義**：Checklist 只檢查真風險，不替不存在的工具背書。
+
+### Linus 哲學 / Linus Philosophy
+
+> "Talk is cheap. Show me the code."
+
+PR 描述不是長篇作文，而是讓 reviewer 能對照程式碼與驗證結果。Linus 風格的 review 是直接、技術、可行動：指出哪裡會壞、為什麼會壞、最小修法是什麼。
+
+### 檢查清單 / Checklist
+
+- [ ] PR 是否只解一個明確問題，沒有混入無關重構或格式化？
+- [ ] 描述是否包含 Problem、Solution、Verification、Risk？
+- [ ] UI 變更是否附截圖或影片，並說明測試 viewport 或瀏覽器？
+- [ ] API contract、資料模型或公開 interface 變更是否標出破壞性影響？
+- [ ] 是否執行與風險相符的 type-check、lint、build 或測試？
+- [ ] 大型 PR 是否提供 review 順序，讓 reviewer 先看資料結構與邊界？
+
+### 範例 / Examples
+
+**不推薦 - 空泛 PR 描述**:
+
+```markdown
+# update page
+
+改一些 UI 和 bug。
+```
+
+這種描述沒有問題、解法、驗證，也看不出 reviewer 該先看哪裡。
+
+**推薦 - 可 review 的 PR 描述**:
+
+```markdown
+## Problem
+
+使用者在資料列表快速切換篩選條件時，畫面可能顯示前一次請求的結果。
+
+## Solution
+
+- 將查詢參數整理成單一 `queryState`
+- 請求完成前比對 request key，忽略過期 response
+- 保留既有 pagination UI，不改公開 props
+
+## Verification
+
+- `pnpm --filter frontend run type-check`
+- `pnpm --filter frontend run lint`
+- 手動測試：Chrome，快速切換篩選條件與頁碼，確認列表不回跳
+
+## Risk
+
+- 目前只處理列表頁查詢競態；其他頁面若有相同問題，需要另開 PR。
+```
+
+**推薦 - 大型 PR 提供 review 順序**:
+
+```markdown
+## Review Order
+
+1. `apps/frontend/src/app/types/`：先確認資料契約。
+2. `apps/frontend/src/app/lib/`：再看 adapter 與資料轉換。
+3. `apps/frontend/src/app/components/`：最後看 UI 組合與互動。
+
+## Notes
+
+本 PR 不調整視覺樣式，只處理資料流與錯誤狀態。
+```
+
+### 常見陷阱 / Common Pitfalls
+
+**陷阱 1: 一個 PR 做太多事**
+
+```markdown
+不推薦：
+
+- 新增功能
+- 順手改命名
+- 重排格式
+- 升級套件
+- 修另一個 bug
+
+推薦：
+
+- 功能 PR 只放功能所需修改
+- 無關重構獨立 PR
+- 套件升級獨立 PR，並附驗證結果
+```
+
+**陷阱 2: Review 只看語法，不看資料邊界**
+
+```markdown
+不推薦：
+
+- 只留言排版、命名偏好
+- 忽略 API response 是否可能為 null
+- 忽略錯誤狀態與重試行為
+
+推薦：
+
+- 先看資料來源與狀態流向
+- 再看錯誤、loading、empty state
+- 最後才看可讀性與命名細節
+```
+
+**陷阱 3: 截圖存在，但不能證明行為**
+
+```markdown
+不推薦：
+
+- 只貼一張完成畫面
+
+推薦：
+
+- 截圖或影片涵蓋 loading、success、empty、error
+- UI 變更標明桌機、筆電或 mobile viewport
+- 互動流程用文字補充，避免 reviewer 猜測
+```
+
+### 參考現有實作 / Reference Implementation
+
+專案中可參考的穩定位置：
+
+- `AGENTS.md` - 工程原則、reviewable patch 與交付前檢查。
+- `.claude/rules/README.md` - 準則總覽、維護方式與自動化層級。
+- `apps/frontend/CLAUDE.md` - 前端架構與開發規範。
+
+### 自動化 / Automation
+
+- **TypeScript**: `pnpm --filter frontend run type-check`。
+- **ESLint**: `pnpm --filter frontend run lint`。
+- **Git Hook**: `.husky/pre-commit` 會在 commit 前執行 type-check 與 lint-staged。
+- **lint-staged**: staged `js/jsx/ts/tsx` 會執行 ESLint fix 與 Prettier write。
+
+---
+
+## 準則 31: Commit Message 規範 / Guideline 31: Commit Message Standards
+
+### 說明 / Description
+
+Commit message 遵循 Conventional Commits。每個 commit 應描述一個邏輯變更，讓 reviewer 能從歷史看出問題、解法與影響範圍。
+
+Commit messages follow Conventional Commits. Each commit should describe one logical change so reviewers can understand the problem, solution, and impact from history.
+
+基本格式：
+
+```text
+<type>(<scope>): <description>
+
+[optional body]
+
+[optional footer]
+```
+
+### 為什麼重要 / Why This Matters
+
+- **歷史可讀**：reviewer 和維護者能快速知道每個 commit 的意圖。
+- **容易 bisect**：一個 commit 一個邏輯變更，出問題時比較容易定位。
+- **支援自動化**：commitlint 可阻擋格式錯誤，release 工具可基於類型整理 changelog。
+- **降低溝通成本**：commit body 可以保存問題、解法與破壞性變更。
+
+### Linus 哲學 / Linus Philosophy
+
+> "Good taste is about eliminating special cases."
+
+這個觀點放在 commit 也成立：一個 commit 如果需要很多層解釋，通常代表它做太多事。把變更切小，commit message 才能短、準、可回溯。
+
+### 檢查清單 / Checklist
+
+- [ ] Commit 是否只包含一個邏輯變更？
+- [ ] Message 是否符合 `<type>(<scope>): <description>`？
+- [ ] `type` 是否使用 commitlint config 支援的類型？
+- [ ] `scope` 是否描述受影響區域，而不是塞進冗長句子？
+- [ ] 破壞性變更是否使用 `!` 或 `BREAKING CHANGE:` footer？
+- [ ] 需要背景時，是否在 commit body 說明問題、解法與驗證？
+
+### 範例 / Examples
+
+**推薦 - 清楚的 Commit Message**:
+
+```bash
+feat(auth): add password reset flow
+fix(table): prevent duplicate fetch on page change
+docs(rules): update collaboration guidelines
+refactor(api): isolate response mapping
+test(user): cover empty state rendering
+chore(deps): update frontend lint dependencies
+```
+
+**推薦 - 有 body 的 Commit Message**:
+
+```bash
+fix(table): ignore stale list responses
+
+快速切換篩選條件時，較慢完成的舊請求可能覆蓋最新結果。
+此變更加入 request key 比對，只接受目前查詢條件對應的 response。
+
+Verification:
+- pnpm --filter frontend run type-check
+- pnpm --filter frontend run lint
+```
+
+**推薦 - 破壞性變更**:
+
+```bash
+feat(api)!: rename user display fields
+
+BREAKING CHANGE: `display_name` is mapped to `displayName` at the frontend adapter boundary.
+```
+
+**不推薦 - 無法回溯的 Commit Message**:
+
+```bash
+update
+fix bug
+feat: add stuff
+fix: final
+```
+
+### 常見陷阱 / Common Pitfalls
+
+**陷阱 1: 用 `chore` 藏功能變更**
+
+```bash
+# 不推薦
+chore: update user page
+
+# 推薦
+feat(user): add profile completion banner
+```
+
+**陷阱 2: 一個 commit 混多種變更**
+
+```bash
+# 不推薦
+feat(user): add form and fix table pagination and update docs
+
+# 推薦
+feat(user): add profile form
+fix(table): correct pagination reset
+docs(readme): update setup notes
+```
+
+**陷阱 3: scope 寫成句子**
+
+```bash
+# 不推薦
+fix(the table page when users click next): prevent duplicate fetch
+
+# 推薦
+fix(table): prevent duplicate fetch on page change
+```
+
+### 參考現有實作 / Reference Implementation
+
+專案中可參考的穩定位置：
+
+- `commitlint.config.js` - 使用 `@commitlint/config-conventional`。
+- `.husky/commit-msg` - commit-msg hook 會執行 commitlint。
+- `package.json` - `npm run commit` 使用 Commitizen 產生 commit message。
+
+### 自動化 / Automation
+
+- **Commitlint**: 檢查 commit message 是否符合 Conventional Commits。
+- **Husky**: `.husky/commit-msg` 在 commit 時執行 commitlint。
+- **Commitizen**: `npm run commit` 提供互動式 commit message 流程。
+- **Standard Version**: 專案已安裝，可用於依 commit 歷史產生版本與 changelog；實際 release 流程需另行定義。
+- **Claude Skill**: `commit-generator`。
+
+---
+
+## 總結 / Summary
+
+協作與溝通的 3 條準則核心思想：
+
+1. **準則 29**: API contract 是跨系統資料結構，文件與型別要同步。
+2. **準則 30**: Pull Request 要小、清楚、可驗證，讓 review 聚焦真風險。
+3. **準則 31**: Commit message 使用 Conventional Commits，讓歷史可讀、可追、可自動化。
+
+**Linus 哲學在協作與溝通中的體現 / Linus Philosophy in Collaboration & Communication**:
+
+- **Data structures first** → 準則 29（先穩住 API contract，再談實作）。
+- **Show the code** → 準則 30（PR 描述必須能對照程式碼與驗證結果）。
+- **Small logical changes** → 準則 31（一個 commit 一個邏輯變更）。
+
+---
+
+## 相關文檔 / Related Documents
+
+- [AGENTS.md](../../AGENTS.md) - 專案工程原則與 Linus 風格開發哲學。
+- [README.md](README.md) - 準則總覽。
+- [template.md](template.md) - 準則文件格式模板。
+- [Conventional Commits](https://www.conventionalcommits.org/) - Conventional Commits 官方規範。
+- [commitlint Local Setup](https://commitlint.js.org/guides/local-setup) - commitlint 與 Husky commit-msg hook 設定。
+
+---
+
+**最後更新 / Last Updated**: 2026-05-16  
+**維護者 / Maintainer**: Frontend Team

--- a/.claude/rules/07-ui-reliability.md
+++ b/.claude/rules/07-ui-reliability.md
@@ -1,0 +1,521 @@
+---
+paths: ['apps/frontend/src/**/*.tsx', 'apps/frontend/src/**/*.ts']
+---
+
+# UI 可靠性 / UI Reliability (準則 32-33)
+
+本文檔涵蓋 UI 在不同 viewport、資料版本與公開介面變更下仍能穩定工作的準則。
+
+This document covers UI reliability guidelines for stable behavior across viewports, data versions, and public interface changes.
+
+---
+
+## 準則 32: 響應式布局 / Guideline 32: Responsive Layout
+
+### 說明 / Description
+
+RWD（響應式網頁設計）不是替每個裝置寫一套畫面，而是讓同一個 UI 在合理的 viewport 範圍內維持可閱讀、可操作、不可重疊。使用 Tailwind CSS 的 mobile-first 斷點與 CSS layout 能力處理版面，不要在 render 階段用 `window.innerWidth` 決定初始畫面。
+
+Responsive Web Design (RWD) should keep one UI readable, usable, and non-overlapping across supported viewport ranges. Use Tailwind CSS mobile-first breakpoints and CSS layout primitives instead of reading `window.innerWidth` during render.
+
+適用範圍：
+
+- 頁面 layout、navigation、表格、dialog、drawer、chart、表單與列表。
+- 所有會被使用者直接操作的 React component。
+- 需要 browser API 的 responsive 行為，例如 `matchMedia`，只能放在 client effect 或專用 hook 中。
+
+具體做法：
+
+- 先定義「此功能必須支援的 viewport」，再決定斷點；不要追逐所有裝置型號。
+- Tailwind 未自訂 `screens` 時，使用預設斷點：`sm` 640px、`md` 768px、`lg` 1024px、`xl` 1280px、`2xl` 1536px。
+- 預設樣式服務小 viewport；用 `sm:`、`md:`、`lg:` 逐步增加空間與欄位。
+- 表格、寬列表與圖表要有明確的 `min-width`、`overflow-x-auto` 或資料分組策略。
+- Dialog、Popover、Sheet 等 overlay 要同時限制 `width`、`max-height` 與 scroll 行為。
+- 需要讀取 viewport 時，用 `useEffect` / `matchMedia`，並保持 server render 與第一次 client render 一致，避免 hydration mismatch。
+
+### 為什麼重要 / Why This Matters
+
+- **避免實際故障**：內容溢出、按鈕被遮住、表格被裁切，都是使用者可見的 bug。
+- **降低維護成本**：用斷點與容器約束解決 layout 問題，比在各頁面散落特例更可維護。
+- **保護 Next.js hydration**：render 階段讀取 `window`、`localStorage` 或時間值，會讓 server HTML 與 client 首次 render 不一致。
+
+### Linus 哲學 / Linus Philosophy
+
+> "Talk is cheap. Show me the code."
+
+Responsive layout does not rest on verbal assurances. A good change should explain which viewport problem it solves through clear CSS constraints, a small number of breakpoints, and actual screenshots or manual verification.
+
+- **Good Taste**: Use fluid layout, sensible breakpoints, and overflow boundaries to eliminate special cases.
+- **Never break userspace**: Existing desktop flows must not break when adding mobile or large-screen support.
+- **Pragmatism**: Support only the viewports that are genuinely needed; do not pile up classes for rare screen sizes.
+- **Simplicity**: Prefer CSS and Tailwind utilities; do not reimplement a layout engine in JavaScript.
+
+### 檢查清單 / Checklist
+
+- [ ] 是否說清楚本次 UI 變更支援哪些 viewport？至少檢查一個窄 viewport、一個常見筆電 viewport、一個桌機 viewport。
+- [ ] 內容是否能垂直捲動完成操作，而不是依賴水平拖拉才能看到主要功能？
+- [ ] 表格、chart、長文字、長檔名或長數字是否不會撐破容器？
+- [ ] Dialog、Popover、Sheet 是否有 `max-height` 與內部 scroll，且 close/action button 不會被擠出畫面？
+- [ ] 是否避免在 render 階段讀取 `window`、`document`、`localStorage`、`Date()` 或 `Math.random()`？
+- [ ] Tailwind responsive class 是否從無前綴樣式開始，再往 `sm:` / `md:` / `lg:` 增加能力？
+
+### 範例 / Examples
+
+**不推薦 ❌ - 用固定寬度假裝穩定**:
+
+```tsx
+function FixedWidthPanel() {
+  return (
+    <section className="w-[1280px]">
+      <h2 className="text-2xl font-semibold">Report</h2>
+      <p className="whitespace-nowrap">
+        A very long generated label that can push actions out of the viewport.
+      </p>
+    </section>
+  )
+}
+```
+
+**推薦 ✅ - 讓容器有邊界，讓文字能收斂**:
+
+```tsx
+function ResponsivePanel() {
+  return (
+    <section className="w-full max-w-screen-xl px-4 sm:px-6 lg:px-8">
+      <h2 className="text-xl font-semibold sm:text-2xl">Report</h2>
+      <p className="max-w-prose break-words text-sm text-muted-foreground">
+        A very long generated label can wrap without pushing actions out of the
+        viewport.
+      </p>
+    </section>
+  )
+}
+```
+
+**推薦 ✅ - 寬表格保留資料完整性，容器負責捲動**:
+
+```tsx
+interface AuditRow {
+  id: string
+  actor: string
+  action: string
+  createdAt: string
+  status: string
+}
+
+function AuditTable({ rows }: { rows: AuditRow[] }) {
+  return (
+    <div className="w-full overflow-x-auto rounded-md border border-border">
+      <table className="min-w-[720px] w-full text-sm">
+        <thead>
+          <tr className="border-b bg-muted/40">
+            <th className="w-[180px] px-3 py-2 text-left">Actor</th>
+            <th className="min-w-[240px] px-3 py-2 text-left">Action</th>
+            <th className="w-[180px] px-3 py-2 text-left">Created At</th>
+            <th className="w-[120px] px-3 py-2 text-left">Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => (
+            <tr key={row.id} className="border-b last:border-0">
+              <td className="px-3 py-2">{row.actor}</td>
+              <td className="px-3 py-2 break-words">{row.action}</td>
+              <td className="px-3 py-2 whitespace-nowrap">{row.createdAt}</td>
+              <td className="px-3 py-2">{row.status}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+```
+
+**推薦 ✅ - Dialog 使用 CSS 約束，不用 JS 計算寬度**:
+
+```tsx
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/app/components/atoms/dialog'
+
+function SettingsDialog({
+  open,
+  onOpenChange,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="w-[calc(100vw-2rem)] max-w-lg max-h-[85vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Settings</DialogTitle>
+          <DialogDescription>
+            Update the options for this workflow.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="grid gap-4 sm:grid-cols-2">{/* form fields */}</div>
+      </DialogContent>
+    </Dialog>
+  )
+}
+```
+
+### 常見陷阱 / Common Pitfalls
+
+**陷阱 1: 把 `sm:` 當成手機樣式**
+
+```tsx
+// ❌ `sm:` 是 640px 以上，不是小螢幕專用。
+<div className="sm:grid sm:grid-cols-2" />
+
+// ✅ 無前綴樣式先服務窄 viewport，再往大 viewport 加能力。
+<div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4" />
+```
+
+**陷阱 2: render 階段讀取 browser-only API**
+
+```tsx
+// ❌ server 沒有 window；即使加 typeof window，也可能讓首次 render 不一致。
+function Toolbar() {
+  const compact = typeof window !== 'undefined' && window.innerWidth < 768
+
+  return compact ? <CompactToolbar /> : <FullToolbar />
+}
+
+// ✅ 第一次 render 保持穩定，client mount 後才讀取 viewport。
+import { useEffect, useState } from 'react'
+
+function useIsNarrowViewport() {
+  const [isNarrow, setIsNarrow] = useState(false)
+
+  useEffect(() => {
+    const query = window.matchMedia('(max-width: 767px)')
+    const sync = () => setIsNarrow(query.matches)
+
+    sync()
+    query.addEventListener('change', sync)
+    return () => query.removeEventListener('change', sync)
+  }, [])
+
+  return isNarrow
+}
+```
+
+**陷阱 3: 用 arbitrary width 堆出不可維護 layout**
+
+```tsx
+// ❌ 單一頁面的魔術數字很快會互相打架。
+<aside className="w-[317px]" />
+<main className="ml-[317px] w-[calc(100vw-317px)]" />
+
+// ✅ 用 layout primitive 表達關係。
+<div className="grid min-h-screen grid-cols-1 lg:grid-cols-[16rem_1fr]">
+  <aside className="hidden border-r lg:block" />
+  <main className="min-w-0 px-4 py-4 lg:px-6" />
+</div>
+```
+
+### 參考現有實作 / Reference Implementation
+
+可優先參考專案中的通用 UI primitive，而不是單一業務頁面：
+
+- `apps/frontend/src/app/components/atoms/dialog.tsx` - Dialog primitive 的寬度、定位與 overlay 基礎。
+- `apps/frontend/src/app/hooks/use-mobile.tsx` - browser-only viewport 判斷應放在 effect 中，不放在 render 階段。
+
+### 自動化 / Automation
+
+- **TypeScript**: `pnpm --filter frontend run type-check` 可抓到 props 型別、client/server 邊界部分錯誤。
+- **ESLint**: `pnpm --filter frontend run lint` 可抓 React Hooks 與 Next.js 規則的一部分；目前 script 使用 `next lint`，Next.js 15 可執行但會提示未來移除，升級 Next.js 16 前應遷到 ESLint CLI。
+- **Next Build**: `pnpm --filter frontend run build` 可抓 prerender、server/client 使用錯誤與部分 hydration 風險。
+- **Manual Review**: 目前沒有既有視覺回歸、E2E 或 component testing 設定；響應式截圖與操作仍需人工或另行導入工具。
+- **Git Hook**: `.husky/pre-commit` 會執行 type-check 與 staged lint/format。
+- **Claude Hook**: `.claude/hooks/check-guidelines.sh` 是提醒腳本，不是 blocking check。
+
+---
+
+## 準則 33: 向後相容性 / Guideline 33: Backward Compatibility
+
+### 說明 / Description
+
+UI 的向後相容性是指：內部重構、資料格式調整、component props 變更或 route/search params 變更後，既有使用者流程與既有呼叫端仍能工作。新增能力通常安全；改名、刪除、改型別、改預設行為通常是破壞性變更。
+
+UI backward compatibility means existing user workflows and callers continue to work after internal refactors, data shape changes, component prop changes, or route/search parameter changes. Additions are usually safe; renames, removals, type changes, and default behavior changes are usually breaking changes.
+
+適用範圍：
+
+- React component props、custom hook 回傳值、共用 helper function。
+- API response/request shape、URL route、search params、form state。
+- `localStorage`、cookie、feature flag、theme 或其他瀏覽器端保存資料。
+- Next.js Server Component 傳給 Client Component 的可序列化 props。
+
+具體做法：
+
+- 新欄位先用 optional，舊欄位保留到呼叫端完成遷移。
+- 改名時保留舊 prop/API，標記 `@deprecated`，內部轉接到新名稱。
+- 修改 persisted data 時加版本與 migration，不要假設使用者沒有舊資料。
+- 改 route 或 search params 時保留 redirect、alias 或 parser fallback。
+- 對外 interface 變更要有驗證：type-check、build、手動 smoke test，必要時補測試工具。
+
+### 為什麼重要 / Why This Matters
+
+- **使用者流程不能被內部改名打斷**：UI 重構不應讓已存在的入口、資料或操作失效。
+- **回滾與 bisect 更容易**：相容層讓變更可以分階段落地，錯誤也更容易定位。
+- **降低跨團隊成本**：公開 props、API shape 和 URL 是契約，不是只有目前檔案知道的細節。
+
+### Linus 哲學 / Linus Philosophy
+
+> "We do not break userspace!"
+
+In frontend terms, userspace is the screen flows, URLs, persisted data, API shapes, and shared component contracts that users already depend on. A theoretically prettier name is not a valid reason to break existing usage.
+
+- **Good Taste**: Use adapters or migrations to contain special cases at boundaries, rather than making every caller patch the hole.
+- **Never break userspace**: Make public contracts backward-compatible first, then remove; never smuggle breaking changes through.
+- **Pragmatism**: Small migration steps are easier to review, test, and roll back than a single large change.
+- **Simplicity**: Compatibility layers should be short, explicit, and have a removal condition; do not accumulate historical baggage indefinitely.
+
+### 檢查清單 / Checklist
+
+- [ ] 是否改到 component props、hook return、helper signature、API shape、route 或 search params？
+- [ ] 舊呼叫端是否仍能 type-check 並保持原行為？
+- [ ] 新欄位是否為 optional，或有清楚 default/migration？
+- [ ] persisted data 是否有版本、parser fallback 或 migration？
+- [ ] deprecation 是否寫在 interface JSDoc、PR 說明或 migration note 中？
+- [ ] 是否用 type-check、build、lint 與手動 smoke test 驗證主要流程？
+
+### 範例 / Examples
+
+**不推薦 ❌ - 改名造成所有呼叫端破壞**:
+
+```typescript
+interface UserSummary {
+  userId: string
+  displayName: string
+}
+
+// ❌ 舊程式使用 id/name 時會直接壞掉。
+function normalizeUser(input: UserSummary) {
+  return {
+    userId: input.userId,
+    displayName: input.displayName,
+  }
+}
+```
+
+**推薦 ✅ - 新 shape 接受舊欄位，邊界集中轉換**:
+
+```typescript
+interface LegacyUserSummary {
+  id: string
+  name: string
+}
+
+interface UserSummary {
+  userId: string
+  displayName: string
+}
+
+type UserSummaryInput = LegacyUserSummary | UserSummary
+
+function normalizeUser(input: UserSummaryInput): UserSummary {
+  if ('userId' in input) {
+    return input
+  }
+
+  return {
+    userId: input.id,
+    displayName: input.name,
+  }
+}
+```
+
+**推薦 ✅ - Props 改名先保留舊名稱**:
+
+```tsx
+interface SearchInputProps {
+  value: string
+  onValueChange?: (value: string) => void
+  /** @deprecated Use onValueChange instead. */
+  onChange?: (value: string) => void
+}
+
+function SearchInput({ value, onValueChange, onChange }: SearchInputProps) {
+  const handleChange = (nextValue: string) => {
+    onValueChange?.(nextValue)
+    onChange?.(nextValue)
+  }
+
+  return (
+    <input
+      value={value}
+      onChange={(event) => handleChange(event.target.value)}
+    />
+  )
+}
+```
+
+**推薦 ✅ - persisted data 用版本與 parser fallback**:
+
+```typescript
+interface PreferencesV1 {
+  theme: 'light' | 'dark'
+}
+
+interface PreferencesV2 {
+  version: 2
+  theme: 'light' | 'dark' | 'system'
+  density: 'compact' | 'comfortable'
+}
+
+const defaultPreferences: PreferencesV2 = {
+  version: 2,
+  theme: 'system',
+  density: 'comfortable',
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function parsePreferences(raw: string | null): PreferencesV2 {
+  if (!raw) return defaultPreferences
+
+  try {
+    const parsed: unknown = JSON.parse(raw)
+
+    if (!isRecord(parsed)) return defaultPreferences
+
+    if (parsed.version === 2) {
+      return {
+        version: 2,
+        theme:
+          parsed.theme === 'light' ||
+          parsed.theme === 'dark' ||
+          parsed.theme === 'system'
+            ? parsed.theme
+            : defaultPreferences.theme,
+        density:
+          parsed.density === 'compact' || parsed.density === 'comfortable'
+            ? parsed.density
+            : defaultPreferences.density,
+      }
+    }
+
+    if (parsed.theme === 'light' || parsed.theme === 'dark') {
+      const legacy: PreferencesV1 = { theme: parsed.theme }
+
+      return {
+        version: 2,
+        theme: legacy.theme,
+        density: defaultPreferences.density,
+      }
+    }
+
+    return defaultPreferences
+  } catch {
+    return defaultPreferences
+  }
+}
+```
+
+### 常見陷阱 / Common Pitfalls
+
+**陷阱 1: TypeScript 沒報錯就以為相容**
+
+```typescript
+// ❌ 型別可編譯，但語意變了：空字串以前代表「不篩選」，現在代表「查無資料」。
+interface FilterState {
+  keyword: string
+}
+
+// ✅ 用明確狀態表達新語意，舊值仍可被轉換。
+interface FilterState {
+  keyword: string | null
+}
+
+function normalizeKeyword(keyword: string | null | undefined) {
+  return keyword?.trim() ? keyword.trim() : null
+}
+```
+
+**陷阱 2: 修改 React key 造成 state 被重置**
+
+```tsx
+// ❌ key 從穩定 id 改成排序後 index，重新排序會讓 row state 對錯資料。
+{
+  rows.map((row, index) => <EditableRow key={index} row={row} />)
+}
+
+// ✅ key 使用資料本身的穩定 identity。
+{
+  rows.map((row) => <EditableRow key={row.id} row={row} />)
+}
+```
+
+**陷阱 3: Server Component 傳不可序列化 props 給 Client Component**
+
+```tsx
+// ❌ Client boundary 的 props 需要可序列化；function 不能從 Server Component 直接傳入。
+<ClientToolbar onRefresh={() => refreshData()} />
+
+// ✅ 傳可序列化資料；互動行為留在 Client Component 內部。
+<ClientToolbar refreshEndpoint="/api/refresh" />
+```
+
+### 參考現有實作 / Reference Implementation
+
+可優先檢查專案中的共用邊界，而不是單一業務頁面：
+
+- `apps/frontend/src/app/components/atoms/index.tsx` - component export 是呼叫端依賴的公開入口，移除或改名要視為破壞性變更。
+- `apps/frontend/src/app/types/` - 共用 TypeScript interface 是 API 與 UI 的資料契約，調整時應考慮 optional 欄位與轉換層。
+- `apps/frontend/src/app/lib/` - normalizer、parser、adapter 適合放在邊界層，避免呼叫端到處處理舊資料。
+
+### 自動化 / Automation
+
+- **TypeScript**: `pnpm --filter frontend run type-check` 可抓公開型別與 props 變更造成的編譯錯誤。
+- **ESLint**: `pnpm --filter frontend run lint` 可抓 React Hooks、Next.js 與部分可維護性問題；目前 script 使用 `next lint`，Next.js 15 可執行但會提示未來移除，升級 Next.js 16 前應遷到 ESLint CLI。
+- **Next Build**: `pnpm --filter frontend run build` 可抓 prerender、server/client boundary 與 route build 風險。
+- **Git Hook**: `.husky/pre-commit` 會執行 type-check 與 staged lint/format。
+- **Manual Review**: API 相容性、URL 相容性、persisted data migration 與主要使用者流程目前仍需人工 review；沒有既有 contract testing 或 E2E testing 設定。
+
+---
+
+## 總結 / Summary
+
+UI 可靠性的 2 條準則核心思想：
+
+1. **準則 32**: 響應式布局要靠明確 viewport、CSS 約束與 hydration-safe 實作，不靠裝置特例。
+2. **準則 33**: 向後相容性要求公開契約分階段演進，不讓內部重構破壞既有使用方式。
+
+**Linus 哲學 / Linus Philosophy in UI Reliability**:
+
+- **Never break userspace** → 準則 33（公開 props、URL、API shape 與保存資料都算使用者依賴）
+- **Pragmatism** → 準則 32（支援真實 viewport，而不是追逐所有裝置）
+- **Simplicity** → 準則 32、33（用 CSS、adapter、migration 解決邊界問題，不把特殊情況散到每個呼叫端）
+
+**向後相容性的基本順序**:
+
+1. **新增 / Addition**：新增 optional 欄位或新 prop。
+2. **轉接 / Adapter**：舊入口保留，內部轉到新實作。
+3. **標記棄用 / Deprecation**：用 JSDoc、PR 說明或 migration note 告知替代方案。
+4. **移除 / Removal**：只在呼叫端完成遷移、驗證完成，且有清楚版本或發布計畫時移除。
+
+---
+
+## 相關文檔 / Related Documents
+
+- [AGENTS.md](../../AGENTS.md) - 專案工程原則與 Linus 風格開發哲學。
+- [README.md](README.md) - 準則總覽。
+- [template.md](template.md) - 準則文件格式模板。
+- [Tailwind CSS Responsive Design](https://tailwindcss.com/docs/responsive-design) - Tailwind 預設斷點與 mobile-first responsive utilities。
+- [Next.js Hydration Error](https://nextjs.org/docs/messages/react-hydration-error) - hydration mismatch 常見原因與修正方向。
+- [Next.js `use client`](https://nextjs.org/docs/app/api-reference/directives/use-client) - Client Component 邊界與可序列化 props。
+
+---
+
+**最後更新 / Last Updated**: 2026-05-15  
+**維護者 / Maintainer**: Frontend Team

--- a/.claude/rules/08-styling.md
+++ b/.claude/rules/08-styling.md
@@ -1,0 +1,563 @@
+---
+paths:
+  [
+    'apps/frontend/src/**/*.tsx',
+    'apps/frontend/src/**/*.ts',
+    'apps/frontend/src/**/*.css',
+    'apps/frontend/tailwind.config.ts',
+    'apps/frontend/components.json',
+  ]
+---
+
+# Styling 與 Theme / Styling And Theme (準則 34-37)
+
+本文檔涵蓋 React / Next.js 專案中的 styling、design token、dark mode、className 組合與 CSS 使用邊界。
+
+This document covers styling, design tokens, dark mode, className composition, and CSS boundaries in React / Next.js projects.
+
+---
+
+## 準則 34: 使用語意化 Design Token / Guideline 34: Use Semantic Design Tokens
+
+### 說明 / Description
+
+元件樣式應優先使用語意化 token，例如 `bg-background`、`text-foreground`、`bg-card`、`text-muted-foreground`、`border-border`、`ring-ring`、`bg-primary`、`text-primary-foreground`。不要在元件內散落品牌色、灰階色票或任意色碼。
+
+Component styles should prefer semantic tokens such as `bg-background`, `text-foreground`, `bg-card`, `text-muted-foreground`, `border-border`, `ring-ring`, `bg-primary`, and `text-primary-foreground`. Do not scatter brand colors, gray palettes, or arbitrary color values inside components.
+
+例外只應出現在 token 定義、第三方套件整合、圖表色盤或臨時除錯，而且要能說明為什麼 semantic token 不足以表達該用途。
+
+Exceptions should stay in token definitions, third-party integrations, chart palettes, or temporary debugging, and the reason must be clear when semantic tokens cannot express the use case.
+
+### 為什麼重要 / Why This Matters
+
+- **主題一致**：同一個 token 可以同時服務 light mode、dark mode 與後續主題調整。
+- **降低回歸風險**：改 token 定義比逐檔搜尋色碼安全。
+- **可審查**：reviewer 能看出顏色語意，而不是猜 `#505050` 在這裡代表什麼。
+- **避免特殊情況擴散**：色碼一旦進入元件，下一個元件很容易複製同一個例外。
+
+### Linus 哲學 / Linus Philosophy
+
+> "Bad programmers worry about the code. Good programmers worry about data structures."
+
+顏色與間距也是資料模型。先把 token 邊界整理好，元件就不需要各自發明特殊情況。
+
+### 檢查清單 / Checklist
+
+- [ ] 元件是否使用 semantic token，而不是 `text-gray-*`、`bg-white`、`border-gray-*` 或任意色碼？
+- [ ] 文字與背景是否成對使用，例如 `bg-primary text-primary-foreground`？
+- [ ] 新增 token 前，是否先確認既有 token 不能表達同一語意？
+- [ ] raw color 是否只出現在 theme、global CSS、圖表色盤或清楚隔離的 integration？
+- [ ] 若新增 token，是否同時定義 light/dark 對應值？
+
+### 範例 / Examples
+
+**不推薦 - 在元件內寫死色票**:
+
+```tsx
+function StatusBadge() {
+  return (
+    <span className="rounded-md border border-gray-200 bg-white px-2 py-1 text-gray-600">
+      Active
+    </span>
+  )
+}
+```
+
+**推薦 - 使用語意化 token**:
+
+```tsx
+function StatusBadge() {
+  return (
+    <span className="rounded-md border border-border bg-card px-2 py-1 text-muted-foreground">
+      Active
+    </span>
+  )
+}
+```
+
+**推薦 - 需要強調狀態時仍使用 token pair**:
+
+```tsx
+function PrimaryAction() {
+  return (
+    <button className="rounded-md bg-primary px-4 py-2 text-primary-foreground hover:bg-primary/90">
+      Save
+    </button>
+  )
+}
+```
+
+### 常見陷阱 / Common Pitfalls
+
+**陷阱 1: 把 Tailwind 預設灰階當成設計系統**
+
+```tsx
+// 不推薦：灰階語意不清，dark mode 也要逐一補
+<p className="text-gray-500 dark:text-gray-400">No data</p>
+
+// 推薦：用 token 表達低強度文字
+<p className="text-muted-foreground">No data</p>
+```
+
+**陷阱 2: hover 狀態自己挑一個色碼**
+
+```tsx
+// 不推薦：hover 色和 theme 沒有關係
+<button className="bg-[#505050] hover:bg-[#404040] text-white">Delete</button>
+
+// 推薦：用 destructive token 表達危險操作
+<button className="bg-destructive text-destructive-foreground hover:bg-destructive/90">
+  Delete
+</button>
+```
+
+### 參考現有實作 / Reference Implementation
+
+- `apps/frontend/tailwind.config.ts` - 將 CSS variables 映射成 Tailwind semantic utilities。
+- `apps/frontend/src/app/globals.css` - 定義 `:root` 與 `.dark` 的 theme variables。
+- `apps/frontend/src/app/components/atoms/card.tsx` - 使用 `bg-card`、`text-card-foreground` 與 `border`。
+
+### 自動化 / Automation
+
+- **ESLint**: 目前沒有阻擋 hardcoded color 的專用規則。
+- **Git Hook**: pre-commit 會跑 type-check 與 staged lint/format，但不會完整判斷 token 語意。
+- **Manual Review**: reviewer 應搜尋 `#[0-9a-fA-F]`、`text-gray`、`bg-white`、`border-gray`、`dark:`。
+
+---
+
+## 準則 35: Dark Mode 由 Token 承擔 / Guideline 35: Let Tokens Carry Dark Mode
+
+### 說明 / Description
+
+專案採 class-based dark mode。元件不應為每個顏色手動補一組 `dark:*`。優先讓 `.dark` 下的 CSS variables 覆寫同一批 token，元件只使用穩定的 semantic class。
+
+The project uses class-based dark mode. Components should not manually add `dark:*` for every color. Prefer overriding the same tokens under `.dark` so components can keep stable semantic classes.
+
+`dark:*` 可以用在少數非 token 屬性，例如圖片反相、特定陰影或暫時無法 token 化的第三方內容。新增前要能說明為什麼 token 不適合。
+
+Use `dark:*` only for non-token properties such as image inversion, specific shadows, or third-party content that cannot be tokenized yet. Explain why a token is not suitable before adding it.
+
+### 為什麼重要 / Why This Matters
+
+- **少改少錯**：切換 theme 時不需要逐一修改元件。
+- **避免組合爆炸**：每個顏色都加 `dark:*` 會讓 className 很快失控。
+- **可測試**：切換 `.dark` 後能用同一套元件檢查對比與可讀性。
+- **使用者體驗**：dark mode 不是反相貼皮，互動狀態也要保持清楚。
+
+### Linus 哲學 / Linus Philosophy
+
+> "Good code has no special cases."
+
+同一個 component 在不同 theme 下應該走同一條 styling 路徑。特殊分支越少，越容易維護。
+
+### 檢查清單 / Checklist
+
+- [ ] 元件顏色是否主要來自 semantic token？
+- [ ] 新增 token 時是否同步定義 `.dark` 值？
+- [ ] 是否避免 `bg-white dark:bg-black` 這類成對硬寫？
+- [ ] focus ring、border、hover、disabled 狀態在 dark mode 是否仍清楚？
+- [ ] 使用 `dark:*` 時是否有明確理由，且範圍足夠小？
+
+### 範例 / Examples
+
+**不推薦 - 元件自行管理 light/dark 色票**:
+
+```tsx
+function EmptyState() {
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white p-6 text-gray-600 dark:border-gray-800 dark:bg-gray-950 dark:text-gray-300">
+      No records
+    </div>
+  )
+}
+```
+
+**推薦 - 由 token 切換 theme**:
+
+```tsx
+function EmptyState() {
+  return (
+    <div className="rounded-lg border border-border bg-card p-6 text-muted-foreground">
+      No records
+    </div>
+  )
+}
+```
+
+**推薦 - 非顏色 token 的小範圍 dark variant**:
+
+```tsx
+import Image from 'next/image'
+
+function Logo() {
+  return (
+    <Image
+      src="/logo.svg"
+      alt="Product logo"
+      width={120}
+      height={32}
+      className="dark:invert"
+    />
+  )
+}
+```
+
+### 常見陷阱 / Common Pitfalls
+
+**陷阱 1: 只測背景，沒有測互動狀態**
+
+```tsx
+// 不推薦：hover 和 focus 在 dark mode 下可能沒有足夠對比
+<button className="bg-white text-gray-900 hover:bg-gray-100 focus:ring-gray-300">
+  Confirm
+</button>
+
+// 推薦：狀態也使用 token
+<button className="bg-primary text-primary-foreground hover:bg-primary/90 focus-visible:ring-ring">
+  Confirm
+</button>
+```
+
+**陷阱 2: 新增 token 只補 light mode**
+
+```css
+/* 不推薦：dark mode 會沿用 light value */
+:root {
+  --warning: 42 96% 50%;
+}
+
+/* 推薦：每個 theme 都有明確值 */
+:root {
+  --warning: 42 96% 50%;
+}
+
+.dark {
+  --warning: 42 90% 62%;
+}
+```
+
+### 參考現有實作 / Reference Implementation
+
+- `apps/frontend/tailwind.config.ts` - `darkMode: ['class']`。
+- `apps/frontend/src/app/globals.css` - `.dark` selector 覆寫 theme variables。
+- `apps/frontend/components.json` - `tailwind.cssVariables` 設為 `true`。
+
+### 自動化 / Automation
+
+- **Manual Review**: 切換 `.dark` 後檢查文字、border、hover、focus、disabled。
+- **Browser Check**: 使用瀏覽器開發者工具切換 `html.dark` 或 theme provider。
+- **ESLint**: 目前沒有完整檢查 dark mode 對比的規則。
+- **Git Hook**: 目前不阻擋 dark mode 視覺回歸。
+
+---
+
+## 準則 36: ClassName 組合與 Variant 邊界 / Guideline 36: ClassName Composition And Variant Boundaries
+
+### 說明 / Description
+
+React 元件使用 `className` 作為樣式入口。需要合併 base class、variant class、條件 class 與呼叫端傳入的 `className` 時，使用 `cn()`。不要用 template literal 或字串相加來組合 Tailwind class，因為衝突 class 不會被正確合併。
+
+React components use `className` as the styling entry point. Use `cn()` when merging base classes, variant classes, conditional classes, and caller-provided `className`. Do not compose Tailwind classes with template literals or string concatenation because conflicting classes will not be merged correctly.
+
+可重用元件的固定變體使用 CVA。一次性頁面布局不需要為了看起來工整而抽 variant，先保持 className 直接可讀。
+
+Use CVA for stable variants in reusable components. One-off page layouts do not need variants just to look tidy; keep className direct and readable first.
+
+### 為什麼重要 / Why This Matters
+
+- **衝突可預期**：`cn()` 搭配 `tailwind-merge` 可以處理 `px-2` 與 `px-4` 這類衝突。
+- **公開 API 清楚**：variant 是元件 API，不是散落在呼叫端的字串約定。
+- **避免過度抽象**：沒有重用需求時，CVA 只會把簡單樣式拆遠。
+- **review 容易**：className 的來源與覆寫順序清楚，問題比較好追。
+
+### Linus 哲學 / Linus Philosophy
+
+> "Talk is cheap. Show me the code."
+
+variant 不是裝飾名詞。只有當它讓呼叫端更清楚、讓狀態更少時，才值得成為 API。
+
+### 檢查清單 / Checklist
+
+- [ ] 是否使用 `cn()` 合併 `className`？
+- [ ] 呼叫端傳入的 `className` 是否保留最後覆寫能力？
+- [ ] 可重用元件的 variant 是否用 CVA 或同等清楚的 mapping 管理？
+- [ ] 一次性布局是否避免過早抽成 variant？
+- [ ] variant 名稱是否描述語意，而不是描述單一色碼或 CSS 細節？
+
+### 範例 / Examples
+
+**不推薦 - 字串相加造成 class 衝突不明**:
+
+```tsx
+interface PanelProps {
+  className?: string
+  isCompact?: boolean
+}
+
+function Panel({ className = '', isCompact = false }: PanelProps) {
+  return (
+    <section
+      className={`rounded-md border border-border p-6 ${
+        isCompact ? 'p-3' : ''
+      } ${className}`}
+    />
+  )
+}
+```
+
+**推薦 - 使用 `cn()` 合併條件 class**:
+
+```tsx
+import { cn } from '@/app/lib/utils'
+
+interface PanelProps {
+  className?: string
+  isCompact?: boolean
+}
+
+function Panel({ className, isCompact = false }: PanelProps) {
+  return (
+    <section
+      className={cn(
+        'rounded-md border border-border p-6',
+        isCompact && 'p-3',
+        className
+      )}
+    />
+  )
+}
+```
+
+**推薦 - 可重用元件使用 CVA**:
+
+```tsx
+import { cva, type VariantProps } from 'class-variance-authority'
+
+import { cn } from '@/app/lib/utils'
+
+const badgeVariants = cva(
+  'inline-flex items-center rounded-md border px-2 py-1 text-xs font-medium',
+  {
+    variants: {
+      variant: {
+        default: 'border-transparent bg-secondary text-secondary-foreground',
+        destructive:
+          'border-transparent bg-destructive text-destructive-foreground',
+        outline: 'border-border text-foreground',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  }
+)
+
+interface BadgeProps
+  extends React.HTMLAttributes<HTMLSpanElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return (
+    <span className={cn(badgeVariants({ variant }), className)} {...props} />
+  )
+}
+```
+
+### 常見陷阱 / Common Pitfalls
+
+**陷阱 1: 把 `className` 放在前面，導致呼叫端覆寫失效**
+
+```tsx
+// 不推薦：base class 可能蓋掉呼叫端傳入的 className
+className={cn(className, 'p-6')}
+
+// 推薦：呼叫端 className 最後合併
+className={cn('p-6', className)}
+```
+
+**陷阱 2: 用 variant 表達顏色細節，而不是語意**
+
+```tsx
+// 不推薦：API 綁死色票
+type ButtonVariant = 'black' | 'gray' | 'white'
+
+// 推薦：API 表達用途
+type ButtonVariant = 'default' | 'secondary' | 'destructive' | 'ghost'
+```
+
+### 參考現有實作 / Reference Implementation
+
+- `apps/frontend/src/app/lib/utils.ts` - `cn()` 使用 `clsx` 與 `tailwind-merge`。
+- `apps/frontend/src/app/components/atoms/button.tsx` - 使用 CVA 管理 `variant` 與 `size`。
+- `apps/frontend/src/app/components/atoms/badge.tsx` - 使用 CVA 管理 badge variants。
+
+### 自動化 / Automation
+
+- **TypeScript**: CVA `VariantProps` 可檢查 variant API。
+- **ESLint**: 可檢查未使用 import 與部分 React 問題，但不會理解 Tailwind 衝突。
+- **Prettier**: 只負責格式，不代表 className 合併正確。
+- **Manual Review**: 搜尋 ``className={` ``、`+ className`、`props.className`。
+
+---
+
+## 準則 37: CSS 只處理全域與難以局部化的樣式 / Guideline 37: CSS Is For Global And Hard-To-Localize Styles
+
+### 說明 / Description
+
+元件樣式優先放在 TSX 的 `className`。CSS 檔案保留給 Tailwind directives、theme variables、`@layer base`、第三方套件覆寫、真正需要 selector 的複雜情境。不要把 component stylesheet 當成預設做法，除非有明確收益。
+
+Prefer TSX `className` for component styles. CSS files should be reserved for Tailwind directives, theme variables, `@layer base`, third-party overrides, and complex cases that genuinely need selectors. Do not make component stylesheets the default unless there is a clear benefit.
+
+`@apply` 不是預設寫法。全域 base style 可以使用 `@apply` 連接 Tailwind token；元件樣式不要用 `@apply` 包成另一層自訂 class，否則 reviewer 需要同時追 TSX 與 CSS 才能理解一個元件。
+
+`@apply` is not the default style authoring pattern. Global base styles can use `@apply` to connect Tailwind tokens; component styles should not hide Tailwind classes behind custom classes because reviewers then need to chase both TSX and CSS to understand one component.
+
+### 為什麼重要 / Why This Matters
+
+- **樣式就近可讀**：元件行為與樣式在同一個地方 review。
+- **減少隱藏依賴**：自訂 CSS class 容易變成全域副作用。
+- **避免框架殘留**：React / Next.js 的元件樣式入口是 `className`，不是每個元件一份 stylesheet。
+- **降低維護成本**：只在需要全域能力時才進 CSS。
+
+### Linus 哲學 / Linus Philosophy
+
+> "Simplicity is the ultimate sophistication."
+
+能用一個 `className` 說清楚的事，不要拆成三個檔案與一個命名慣例。
+
+### 檢查清單 / Checklist
+
+- [ ] 元件專屬樣式是否留在 `className`？
+- [ ] CSS 是否只包含 Tailwind directives、theme variables、base layer 或第三方覆寫？
+- [ ] 新增 `@apply` 前，是否確認直接寫 className 會更糟？
+- [ ] 自訂 selector 是否不會影響非預期元件？
+- [ ] 全域 CSS 修改是否已檢查 light/dark mode 與常見頁面？
+
+### 範例 / Examples
+
+**不推薦 - 為單一元件新增全域 CSS class**:
+
+```css
+.toolbarButton {
+  @apply rounded-md border border-border bg-background px-3 py-2 text-sm;
+}
+```
+
+```tsx
+function ToolbarButton() {
+  return <button className="toolbarButton">Filter</button>
+}
+```
+
+**推薦 - 元件樣式留在 `className`**:
+
+```tsx
+function ToolbarButton() {
+  return (
+    <button className="rounded-md border border-border bg-background px-3 py-2 text-sm">
+      Filter
+    </button>
+  )
+}
+```
+
+**推薦 - CSS 處理全域 token 與 base layer**:
+
+```css
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+  :root {
+    --background: 0 0% 100%;
+    --foreground: 0 0% 3.9%;
+  }
+
+  .dark {
+    --background: 0 0% 3.9%;
+    --foreground: 0 0% 98%;
+  }
+
+  body {
+    @apply bg-background text-foreground;
+  }
+}
+```
+
+### 常見陷阱 / Common Pitfalls
+
+**陷阱 1: 用 CSS class 藏元件狀態**
+
+```css
+/* 不推薦：狀態和 component props 分離 */
+.buttonDanger {
+  @apply bg-destructive text-destructive-foreground;
+}
+```
+
+```tsx
+// 推薦：狀態留在 component API
+<Button variant="destructive">Delete</Button>
+```
+
+**陷阱 2: 任意 selector 造成全域副作用**
+
+```css
+/* 不推薦：所有 button 都被影響 */
+button {
+  @apply rounded-md;
+}
+
+/* 推薦：只保留真正全域的基礎樣式 */
+body {
+  @apply bg-background text-foreground;
+}
+```
+
+### 參考現有實作 / Reference Implementation
+
+- `apps/frontend/src/app/globals.css` - 放置 Tailwind directives、theme variables 與 base layer。
+- `apps/frontend/src/app/components/atoms/button.tsx` - 元件樣式集中在 `className` 與 CVA。
+- `apps/frontend/src/app/components/atoms/card.tsx` - 以 `className` 暴露可覆寫樣式入口。
+
+### 自動化 / Automation
+
+- **Prettier**: 格式化 CSS / TSX。
+- **ESLint**: 不會阻擋過度使用 `@apply` 或全域 selector。
+- **Manual Review**: 新增 CSS 時檢查是否真的需要 selector 或全域層級。
+- **Git Hook**: pre-commit 會執行既有 type-check 與 staged lint/format。
+
+---
+
+## 總結 / Summary
+
+Styling 與 Theme 的 4 條準則核心思想：
+
+1. **準則 34**: 元件使用 semantic design token，不散落 raw color。
+2. **準則 35**: dark mode 由 token 承擔，避免每個元件各自補色票。
+3. **準則 36**: 用 `cn()` 與必要的 CVA 管理 className 組合與 variant API。
+4. **準則 37**: CSS 只處理全域與難以局部化的樣式，元件樣式優先留在 TSX。
+
+**Linus 哲學在 Styling 與 Theme 中的體現**:
+
+- **Good Taste** → 準則 34、35（把 theme 當成資料模型，消除每個元件的特殊色彩分支）。
+- **Pragmatism** → 準則 36（variant 只在能降低實際重複與錯誤時才抽象）。
+- **Simplicity** → 準則 37（能就近讀懂的樣式，不拆到全域 CSS）。
+- **Never break userspace** → 準則 35（theme 切換不能破壞既有可讀性與互動狀態）。
+
+---
+
+## 相關文檔 / Related Documents
+
+- [AGENTS.md](../../AGENTS.md) - Linus Torvalds 開發哲學。
+- [README.md](README.md) - 準則總覽。
+- [template.md](template.md) - 準則文件格式模板。
+- [Tailwind CSS Theme Variables](https://tailwindcss.com/docs/theme) - design token 與 utility class 的關係。
+- [shadcn/ui Theming](https://ui.shadcn.com/docs/theming) - CSS variables、theme tokens 與 dark mode。
+
+---
+
+**最後更新 / Last Updated**: 2026-05-15  
+**維護者 / Maintainer**: Frontend Team

--- a/.claude/rules/README.md
+++ b/.claude/rules/README.md
@@ -1,0 +1,216 @@
+---
+paths: [__disabled__]
+---
+
+# 前端開發準則總覽 / Frontend Development Guidelines Overview
+
+本目錄包含前端專案的開發準則。準則的目的不是替工程師背誦規章，而是讓每次變更都能回答四件事：解決什麼問題、為什麼是這個形狀、如何驗證、還剩什麼風險。
+
+This directory contains frontend development guidelines. The goal is not rule memorization, but making every change explain the problem, the chosen shape, the verification, and the remaining risk.
+
+---
+
+## 分類索引 / Category Index
+
+| 分類               | Category                        | 準則編號 | Guidelines   | 檔案                                                     |
+| ------------------ | ------------------------------- | -------- | ------------ | -------------------------------------------------------- |
+| 組件生命週期與規範 | Component Lifecycle & Standards | 1-7      | 7 guidelines | [01-component-standards.md](01-component-standards.md)   |
+| 程式碼品質         | Code Quality                    | 8-13     | 6 guidelines | [02-code-quality.md](02-code-quality.md)                 |
+| 前端效能           | Frontend Performance            | 14-20    | 7 guidelines | [03-frontend-performance.md](03-frontend-performance.md) |
+| 前端安全           | Frontend Security               | 21-25    | 5 guidelines | [04-frontend-security.md](04-frontend-security.md)       |
+| 狀態與錯誤處理     | State & Error Handling          | 26-28    | 3 guidelines | [05-state-error-handling.md](05-state-error-handling.md) |
+| 協作與溝通         | Collaboration & Communication   | 29-31    | 3 guidelines | [06-collaboration.md](06-collaboration.md)               |
+| UI 可靠性          | UI Reliability                  | 32-33    | 2 guidelines | [07-ui-reliability.md](07-ui-reliability.md)             |
+| Styling 與 Theme   | Styling And Theme               | 34-37    | 4 guidelines | [08-styling.md](08-styling.md)                           |
+
+補充文件：
+
+- [typescript.md](typescript.md) - 純 TypeScript 補充準則（TS-1–TS-3, TS-5）：型別邊界標注、runtime narrowing、discriminated union、泛型與 utility type 使用原則。
+- [template.md](template.md) - 新增或重寫準則時使用的格式模板。
+
+---
+
+## 快速參考 / Quick Reference
+
+### 組件生命週期與規範 / Component Lifecycle & Standards (1-7)
+
+1. **Props 類型定義 / Props Type Definition** - Props 是組件資料邊界，必須有明確 TypeScript interface。
+2. **Callback Props 規範 / Callback Props** - 子組件對外事件使用 `onXxx` callback props。
+3. **Custom Hook 與副作用 / Custom Hooks And Effects** - Hook 只在降低複雜度時抽出，副作用要有完整依賴與 cleanup。
+4. **Next.js Client Boundary / Next.js Client Boundary** - 專案不以 SSR 為主，`'use client'` 與 client runtime 邊界要清楚。
+5. **Import 與公開 API / Imports And Public API** - 使用穩定 import 路徑，避免公開內部實作。
+6. **組件大小與拆分 / Component Size And Splitting** - 單一 component file 建議不超過 200 行，拆分要按責任而非行數。
+7. **檢查與格式化 / Checks And Formatting** - 完成前執行相關 type-check、lint、format 流程。
+
+### 程式碼品質 / Code Quality (8-13)
+
+8. **資料邊界與封裝 / Data Boundaries And Encapsulation** - 只暴露呼叫端需要的資料與操作。
+9. **命名與語意 / Naming And Semantics** - 命名要表達 domain 語意，避免 pinyin、無意義縮寫與模糊暫存名。
+10. **函數拆分與控制流 / Function Splitting And Control Flow** - 函數短而直接，巢狀維持在 3 層以內。
+11. **重構候選方案 / Refactoring Candidate Moves** - 重構要刪掉特殊情況或縮小邊界，不新增無證據的抽象。
+12. **React Hooks 正確性 / React Hooks Correctness** - Hooks 先求正確，memo 和 effect 只在有明確理由時使用。
+13. **最小可行實作 / Smallest Working Implementation** - 用最小實作解決真實問題，新增複雜度前先說明取捨。
+
+### 前端效能 / Frontend Performance (14-20)
+
+14. **控制 Client Boundary 與 Lazy Loading / Control Client Boundaries and Lazy Loading** - 不以 SSR 作為主要效能策略，重元件與瀏覽器 API 才 lazy load。
+15. **避免不必要的 Client State 與 Effect / Avoid Unnecessary Client State and Effects** - 不重複保存可推導資料，副作用必須清理。
+16. **先測量，再優化 / Measure Before Optimizing** - 效能變更需要 baseline、before/after 與取捨說明。
+17. **避免 N+1 請求與 Waterfall / Avoid N+1 Requests and Data Waterfalls** - 批次資料用單次 API 或並行請求取得。
+18. **Memoization 服務資料流，不服務焦慮 / Memoization Serves Data Flow, Not Anxiety** - `useMemo`、`useCallback`、`React.memo` 必須有實際理由。
+19. **大列表先分頁，再考慮虛擬捲動 / Paginate Large Lists Before Virtualizing** - 先用 UI 分頁與 API 分頁控制 render 範圍。
+20. **Bundle 與資產大小要可見 / Keep Bundle and Assets Visible** - 用 Next build、Network、Lighthouse 或 bundle analyzer 檢查 bundle、圖片、字體與依賴。
+
+### 前端安全 / Frontend Security (21-25)
+
+21. **跨站腳本攻擊（XSS）防護 / XSS Protection** - 使用 JSX 預設轉義，避免直接使用 `dangerouslySetInnerHTML`。
+22. **輸入驗證 / Input Validation** - 前端驗證只改善 UX，安全驗證仍需在 API 或可信任邊界執行。
+23. **敏感資料處理 / Sensitive Data Handling** - 不把 token、secret 或不可公開資料放進瀏覽器可讀取位置。
+24. **CORS（跨來源資源共享）與同源政策 / CORS And Same-Origin Policy** - 正式環境必須有明確來源與允許清單。
+25. **套件安全稽核 / Dependency Security Audit** - 新套件與安全更新需納入 review。
+
+### 狀態與錯誤處理 / State & Error Handling (26-28)
+
+26. **狀態來源與錯誤邊界 / State Sources And Error Boundaries** - 資料來源、client state、remote/API state 與 Error Boundary 要有清楚邊界。
+27. **可預期錯誤與使用者訊息 / Expected Errors And User Messages** - 表單驗證、API 失敗與查無資料應回到 UI state，不顯示技術細節。
+28. **Loading、Empty 和 Error State / Loading, Empty And Error State** - 非同步操作與 TanStack Query 查詢應有清楚 loading、success、empty、error 狀態。
+
+### 協作與溝通 / Collaboration & Communication (29-31)
+
+29. **API 契約與類型同步 / API Contract & Type Sync** - 前端與 API provider 的契約必須文件化並同步 TypeScript types。
+30. **Code Review 規範 / Code Review Standards** - PR 說明應包含 What、Why、How、Verification。
+31. **Commit Message 規範 / Commit Message Standards** - 遵循 Conventional Commits。
+
+### UI 可靠性 / UI Reliability (32-33)
+
+32. **響應式布局 / Responsive Layout** - 支援已定義的窄 viewport、筆電與桌機版面，避免內容溢出與 hydration mismatch。
+33. **向後相容性 / Backward Compatibility** - 不破壞現有使用者流程、URL、保存資料與公開介面。
+
+### Styling 與 Theme / Styling And Theme (34-37)
+
+34. **使用語意化 Design Token / Use Semantic Design Tokens** - 元件使用 semantic token，不散落 raw color。
+35. **Dark Mode 由 Token 承擔 / Let Tokens Carry Dark Mode** - 以 `.dark` 覆寫 token，避免每個元件各自管理色票。
+36. **ClassName 組合與 Variant 邊界 / ClassName Composition And Variant Boundaries** - 使用 `cn()` 合併 className，必要時用 CVA 管理可重用 variant。
+37. **CSS 只處理全域與難以局部化的樣式 / CSS Is For Global And Hard-To-Localize Styles** - 元件樣式優先留在 TSX，CSS 保留給 token、base layer 與全域覆寫。
+
+---
+
+## 使用方式 / Usage
+
+### 開發時 / During Development
+
+1. 先確認這次變更的實際問題與最小範圍。
+2. 找到對應準則文件，優先閱讀和本次修改相關的條目。
+3. 修改後執行和變更風險相符的驗證命令。
+4. 在 PR 或交付說明中寫清楚問題、解法、驗證與剩餘風險。
+
+### 維護準則文件時 / Maintaining Rule Documents
+
+準則文件要服務工程師維護，不要服務一次性的情境描述。尤其是 [03-frontend-performance.md](03-frontend-performance.md)、[04-frontend-security.md](04-frontend-security.md)、[05-state-error-handling.md](05-state-error-handling.md)、[06-collaboration.md](06-collaboration.md)、[07-ui-reliability.md](07-ui-reliability.md) 與 [08-styling.md](08-styling.md)，請維持通用 Next.js / React / TypeScript 原則，不把示範資料、短期 workaround、單一頁面或特定檔案路徑寫成標準。若已決定導入工具（例如 TanStack Query 或 API type generator），要標清楚是導入後標準；若尚未決定，則不要寫成既有檢查。
+
+以 Linus 風格審查準則文件時，至少確認：
+
+- **真問題**：每條準則都能說清楚避免什麼實際成本或錯誤。
+- **最小做法**：建議優先是小而直接的做法，不先引入複雜工具。
+- **可驗證**：效能規則要能指向 build、Profiler、Network、Lighthouse 或可重現操作。
+- **可維護**：範例用穩定、通用命名；避免依賴當前暫定頁面。
+
+### 目前可用的自動化 / Current Automation
+
+目前專案有以下實際存在的自動化：
+
+- **Husky pre-commit**: `.husky/pre-commit` 會執行 `pnpm --filter frontend run type-check` 與 `pnpm --filter frontend run lint-staged`。
+- **lint-staged**: `apps/frontend/package.json` 會對 staged `js/jsx/ts/tsx` 執行 `eslint --fix` 與 `prettier --write`。
+- **commit-msg**: `.husky/commit-msg` 會執行 commitlint。
+- **Guideline reminder script**: `.claude/hooks/check-guidelines.sh` 目前是提醒腳本，不是 blocking check。
+
+目前沒有確認存在的 `/guideline-review` 指令，也沒有針對所有 37 條準則的完整自動化掃描。若要做完整審查，請以本 README 的分類索引搭配各準則文件人工 review。
+
+### 常用驗證命令 / Common Verification Commands
+
+```bash
+pnpm --filter frontend run type-check
+pnpm --filter frontend run lint
+pnpm --filter frontend run build
+pnpm --filter frontend run format
+```
+
+注意：`format` 會寫入檔案。若只想檢查格式，需先新增對應 script，或在執行後檢查 diff。
+
+注意：`lint` 目前執行 `next lint`。Next.js 15 仍可執行，但會提示此命令將在 Next.js 16 移除；升級前應遷到 ESLint CLI。
+
+---
+
+## 哲學基礎 / Philosophical Foundation
+
+這些準則延續 [AGENTS.md](../../AGENTS.md) 的工程取向：簡單核心、可審查 patch、快速回饋、長期可維護。
+
+### Good Taste
+
+- **準則 8**：先整理資料邊界，避免每個呼叫端處理內部細節。
+- **準則 11**：重構要消除特殊情況，而不是新增更花俏的特殊情況。
+
+### Never Break Userspace
+
+- **準則 4**：Client runtime 邊界變更不能破壞 hydration 行為。
+- **準則 33**：公開介面與使用者流程不能被內部重構順手破壞。
+
+### Pragmatism
+
+- **準則 13**：只為真實問題付出複雜度。
+- **準則 16**：效能優化要有測量或清楚觀察。
+
+### Simplicity
+
+- **準則 9**：命名清楚，減少需要註解補救的程式碼。
+- **準則 10**：控制流平坦，函數責任單一。
+
+---
+
+## 自動化層級 / Automation Levels
+
+| 自動化程度 | Level               | 準則                           | 說明                                                                                           |
+| ---------- | ------------------- | ------------------------------ | ---------------------------------------------------------------------------------------------- |
+| 可阻擋     | Blocking            | 7, 31                          | Husky 可阻擋 type-check、staged lint/format、commitlint 問題。                                 |
+| 半自動     | Partially Automated | 1, 3, 4, 12, 36                | TypeScript、ESLint、Next.js、CVA types 可檢查部分型別、Hooks、App Router 與 variant API 問題。 |
+| 人工審查   | Manual Review       | 2, 5-6, 8-11, 13-30, 32-35, 37 | 命名、封裝、架構、效能取捨、安全語意、token 使用、CSS 邊界與相容性仍需工程師 review。          |
+
+---
+
+## 準則優先級 / Guideline Priority
+
+### P0 - 會直接導致錯誤或阻擋交付
+
+- **準則 1-4**: Props、Callback、Hooks、Client runtime 邊界。
+- **準則 7**: TypeScript、ESLint、Prettier 基礎檢查。
+- **準則 21-25**: 前端安全。
+- **準則 33**: 向後相容性。
+
+### P1 - 會明顯提高維護成本
+
+- **準則 8-13**: 程式碼品質。
+- **準則 26-28**: 狀態與錯誤處理。
+- **準則 29-31**: API 契約、Code Review、Commit。
+
+### P2 - 依風險和資料量逐步加強
+
+- **準則 14-20**: 前端效能。
+- **準則 32**: 響應式布局。
+- **準則 34-37**: Styling 與 theme。
+- **補充文件 09**: TypeScript 細節。
+
+---
+
+## 相關文檔 / Related Documents
+
+- [AGENTS.md](../../AGENTS.md) - 專案工程原則與 Linus 風格開發哲學。
+- [apps/frontend/CLAUDE.md](../../apps/frontend/CLAUDE.md) - 前端專案架構與開發規範。
+- [apps/frontend/README.md](../../apps/frontend/README.md) - Next.js app 基礎說明。
+- [template.md](template.md) - 準則文件格式模板。
+
+---
+
+**最後更新 / Last Updated**: 2026-05-16
+**維護者 / Maintainer**: Frontend Team
+**版本 / Version**: 1.3.8
+**參考 / Reference**: AGENTS.md 工程原則，適配 Next.js 15 / React 19 / TypeScript / Tailwind CSS

--- a/.claude/rules/template.md
+++ b/.claude/rules/template.md
@@ -1,0 +1,147 @@
+---
+paths: [__disabled__]
+---
+
+# {分類名稱} / {Category Name} (準則 X-Y)
+
+本文檔涵蓋 {簡短描述分類內容}。
+
+This document covers {brief description in English}.
+
+---
+
+## 準則 X: {準則標題} / Guideline X: {Guideline Title}
+
+### 說明 / Description
+
+{詳細說明這條準則的內容，應該包含：
+
+- 準則的核心要求
+- 適用範圍
+- 具體做法}
+
+### 為什麼重要 / Why This Matters
+
+- **{重點 1}**：{解釋為什麼重要}
+- **{重點 2}**：{解釋為什麼重要}
+- **{重點 3}**：{解釋為什麼重要}
+
+### Linus Philosophy
+
+> "{Quote from Linus}"
+
+{Explain how this guideline reflects Linus Philosophy:
+
+- Good Taste: eliminate special cases
+- Never break userspace: backward compatibility
+- Pragmatism: solve real problems
+- Simplicity: keep it simple}
+
+### 檢查清單 / Checklist
+
+- [ ] {檢查項目 1}
+- [ ] {檢查項目 2}
+- [ ] {檢查項目 3}
+- [ ] {檢查項目 4}
+- [ ] {檢查項目 5}
+
+### 範例 / Examples
+
+**不推薦 ❌ - {錯誤做法描述}**:
+
+```vue
+<!-- 或 typescript -->
+{錯誤範例程式碼}
+```
+
+**推薦 ✅ - {正確做法描述}**:
+
+```vue
+<!-- 或 typescript -->
+{正確範例程式碼}
+```
+
+**推薦 ✅ - {進階用法描述}**:
+
+```vue
+{進階範例程式碼}
+```
+
+### 常見陷阱 / Common Pitfalls
+
+**陷阱 1: {陷阱描述}**
+
+```typescript
+// ❌ 錯誤做法
+{
+  錯誤程式碼
+}
+
+// ✅ 正確做法
+{
+  正確程式碼
+}
+```
+
+**陷阱 2: {陷阱描述}**
+
+```typescript
+// ❌ 錯誤做法
+{
+  錯誤程式碼
+}
+
+// ✅ 正確做法
+{
+  正確程式碼
+}
+```
+
+### 參考現有實作 / Reference Implementation
+
+專案中的優秀範例：
+
+- `{檔案路徑 1}` - {簡短說明}
+- `{檔案路徑 2}` - {簡短說明}
+
+### 自動化 / Automation
+
+- **ESLint**: {相關規則名稱}
+- **Git Hook**: 🤖 / ⚠️ / ℹ️ {強制 / 警告 / 提示}
+- **Claude Hook**: ✅ {觸發條件和行為}
+- **Claude Skill**: {相關 skill 名稱}
+
+---
+
+## 準則 X+1: {下一條準則標題}
+
+{重複上述結構}
+
+---
+
+## 總結 / Summary
+
+{分類名稱}的 X 條準則核心思想：
+
+1. **準則 X**: {一句話總結}
+2. **準則 X+1**: {一句話總結}
+3. **準則 X+2**: {一句話總結}
+   ...
+
+**Linus Philosophy in {category name}**:
+
+- {哲學原則} → 準則 X（{如何體現}）
+- {哲學原則} → 準則 Y（{如何體現}）
+
+---
+
+## 相關文檔 / Related Documents
+
+- [AGENTS.md](../../AGENTS.md) - Linus Torvalds 開發哲學
+- [README.md](README.md) - 準則總覽
+- [{其他相關文檔}]({路徑})
+
+---
+
+**最後更新 / Last Updated**: 2025-12-30  
+**維護者 / Maintainer**: ML Web Frontend Team

--- a/.claude/rules/typescript.md
+++ b/.claude/rules/typescript.md
@@ -1,0 +1,366 @@
+---
+paths:
+  [
+    'apps/frontend/src/**/*.ts',
+    'apps/frontend/src/**/*.tsx',
+    'apps/frontend/*.config.ts',
+    'apps/frontend/tsconfig.json',
+  ]
+---
+
+# TypeScript (準則 TS-1 – TS-3, TS-5)
+
+TypeScript 補充準則：讓型別反映真實資料邊界，而不是用型別語法包裝猜測。
+
+TypeScript supplemental guidelines. The focus is making types describe real data boundaries instead of wrapping guesses in type syntax.
+
+---
+
+## 準則 TS-1: 標注邊界，推論其餘 / Guideline TS-1: Annotate Boundaries, Infer the Rest
+
+### 說明 / Description
+
+跨檔案使用的資料模型、helper 回傳值必須有明確型別。物件契約用 `interface`；union、tuple、primitive alias、function alias 用 `type`。區域變數與簡單 callback 讓推論處理。
+
+Object contracts crossing file boundaries need explicit types: shared models, API adapter output, exported helpers. Use `interface` for objects; use `type` for unions, tuples, primitive aliases, and function aliases. Let inference handle local variables and simple callbacks.
+
+### 為什麼重要 / Why This Matters
+
+- **可審查**：邊界清楚，reviewer 不必追呼叫鏈。
+- **低噪音**：只標注重要邊界，讓重要型別更醒目。
+- **可重構**：公開契約固定，內部實作才有空間改。
+
+### Linus 哲學 / Linus Philosophy
+
+> The goal is not to make every line clever, but to make the data model simple enough that mistakes become obvious.
+
+Annotate the real boundaries; let the compiler handle the rest. Filling every local variable with explicit types is noise, not safety.
+
+### 檢查清單 / Checklist
+
+- [ ] 跨檔案的資料模型與 helper 回傳值有明確型別。
+- [ ] 物件契約用 `interface`，union/tuple/alias 用 `type`。
+- [ ] 不新增 `any`；真正未知的資料用 `unknown` 並在使用前縮小型別。
+- [ ] 匯出的 helper function 有明確 return type。
+
+### 範例 / Examples
+
+**不推薦 ❌ - 用 `any` 讓邊界消失**:
+
+```typescript
+export function getDisplayName(user: any) {
+  return user.profile.name
+}
+```
+
+**推薦 ✅ - 邊界清楚，區域推論**:
+
+```typescript
+interface UserProfile { name: string }
+interface User { profile: UserProfile }
+
+export function getDisplayName(user: User): string {
+  return user.profile.name
+}
+
+// 區域變數：推論已足夠
+const total = price * quantity
+```
+
+**推薦 ✅ - union 與 tuple 用 `type`**:
+
+```typescript
+type RequestStatus = 'idle' | 'loading' | 'success' | 'error'
+type Coordinate = [x: number, y: number]
+```
+
+### 常見陷阱 / Common Pitfalls
+
+**陷阱: 為省事把外部資料宣告成 `Record<string, any>`**
+
+```typescript
+// ❌ TypeScript 幫不上忙
+const payload: Record<string, any> = await response.json()
+
+// ✅ 先承認未知，再縮小
+const payload: unknown = await response.json()
+```
+
+### 參考現有實作 / Reference Implementation
+
+- `apps/frontend/src/app/types/chart.ts` - literal union 與 domain interface 分開表達。
+- `apps/frontend/tailwind.config.ts` - `satisfies Config` 保留推論並檢查設定形狀。
+
+### 自動化 / Automation
+
+- **TypeScript**: `strict: true`、`noEmit: true`
+- **ESLint**: `@typescript-eslint/no-explicit-any`
+- **Git Hook**: 🤖 `.husky/pre-commit` 執行 type-check 與 staged lint/format
+- **Verification**: `pnpm --filter frontend run type-check`
+
+---
+
+## 準則 TS-2: Runtime 邊界先縮小型別 / Guideline TS-2: Narrow Runtime Boundaries First
+
+### 說明 / Description
+
+TypeScript 型別只在編譯期存在。來自 `fetch().json()`、`localStorage`、URL params、表單或第三方 callback 的資料，在 runtime 仍然不可信。先以 `unknown` 接住，再用小而直接的型別守衛轉成內部型別。
+
+TypeScript types exist at compile time only. Data from external sources is untrusted at runtime. Receive it as `unknown`, then convert through a small type guard.
+
+API adapter 的整體設計請參考 [準則 29](06-collaboration.md)。
+
+### 為什麼重要 / Why This Matters
+
+- **避免假安全**：`as SomeType` 不會檢查 runtime 資料。
+- **錯誤集中**：guard 失敗的位置就是資料契約破掉的位置。
+- **核心保持乾淨**：內部程式碼不用到處防禦未知欄位。
+
+### Linus 哲學 / Linus Philosophy
+
+> Push special cases to the boundary; keep the core logic clean.
+
+One explicit guard at the entry point is simpler and more reviewable than defensive checks scattered through the caller code.
+
+### 檢查清單 / Checklist
+
+- [ ] 外部資料以 `unknown` 接住，使用前有型別守衛或 adapter。
+- [ ] 不用雙重 assertion（`as unknown as Target`）跳過編譯器。
+- [ ] 不把 TypeScript type 當成 runtime validation。
+- [ ] 只在邊界重複且成本明確時，才導入 schema validation 套件。
+
+### 範例 / Examples
+
+**不推薦 ❌ - 用 assertion 假裝資料正確**:
+
+```typescript
+const item = (await response.json()) as Item
+renderItem(item.name)
+```
+
+**推薦 ✅ - 型別守衛縮小後才使用**:
+
+```typescript
+interface Item { id: string; name: string }
+
+function isItem(value: unknown): value is Item {
+  if (typeof value !== 'object' || value === null) return false
+  const r = value as Record<string, unknown>
+  return typeof r.id === 'string' && typeof r.name === 'string'
+}
+
+const payload: unknown = await response.json()
+if (!isItem(payload)) throw new Error('Invalid item response')
+
+renderItem(payload.name)
+```
+
+### 常見陷阱 / Common Pitfalls
+
+**陷阱: 用 optional chaining 掩蓋資料契約錯誤**
+
+```typescript
+// ❌ 失敗時只得到 undefined，錯誤來源消失
+const name = payload?.item?.name
+
+// ✅ 先驗證，再使用
+if (!isItemResponse(payload)) return { status: 'error' }
+```
+
+### 自動化 / Automation
+
+- **TypeScript**: `strict` 阻擋部分未縮小的 `unknown` 使用。
+- **Manual Review**: 檢查 `as Target` 是否只出現在已驗證的邊界。
+
+---
+
+## 準則 TS-3: 用型別表達互斥狀態 / Guideline TS-3: Model Exclusive States with Types
+
+### 說明 / Description
+
+互斥狀態用 discriminated union 表達，而不是用多個 boolean 組合。Boolean 可以同時為 true，製造未定義行為；discriminated union 讓不可能狀態在型別層級就不可表示。
+
+Use discriminated unions for mutually exclusive states instead of multiple booleans. Booleans can be true simultaneously and create undefined state combinations.
+
+### 為什麼重要 / Why This Matters
+
+- **不可能狀態不可表示**：型別直接阻擋矛盾 state。
+- **分支更完整**：`switch` 讓 reviewer 看出每個狀態如何處理。
+
+### Linus 哲學 / Linus Philosophy
+
+> Good data structures make control flow disappear.
+
+Model state correctly and the downstream branches shrink on their own, along with the special cases.
+
+### 檢查清單 / Checklist
+
+- [ ] 互斥狀態使用 `status` 或 `type` 作為 discriminant。
+- [ ] 每個狀態只帶該狀態需要的資料。
+- [ ] 不用 `isLoading`、`isError`、`hasData` 同時描述同一組 async state。
+
+### 範例 / Examples
+
+**不推薦 ❌ - boolean state 可以互相矛盾**:
+
+```typescript
+interface AsyncState {
+  isLoading: boolean
+  isError: boolean
+  data?: Item
+}
+```
+
+**推薦 ✅ - discriminated union 讓狀態互斥**:
+
+```typescript
+type AsyncState =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'success'; data: Item }
+  | { status: 'error'; message: string }
+```
+
+**推薦 ✅ - `satisfies` 確保 map 覆蓋所有狀態**:
+
+```typescript
+const statusLabel = {
+  idle: 'Ready',
+  loading: 'Loading',
+  success: 'Loaded',
+  error: 'Failed',
+} satisfies Record<AsyncState['status'], string>
+```
+
+### 常見陷阱 / Common Pitfalls
+
+**陷阱: 使用 string 但不限制可用值**
+
+```typescript
+// ❌ 任何字串都能進來
+let status: string = 'loading'
+
+// ✅ 狀態集合清楚
+type Status = 'idle' | 'loading' | 'success' | 'error'
+let status: Status = 'loading'
+```
+
+### 自動化 / Automation
+
+- **TypeScript**: 建議在 `switch` 搭配 `assertNever` 或 `satisfies never` 做 exhaustiveness check。
+- **Manual Review**: 檢查 boolean state 組合是否能改成單一狀態模型。
+
+---
+
+## 準則 TS-5: 型別工具要服務資料關係 / Guideline TS-5: Type Tools Must Serve Data Relationships
+
+### 說明 / Description
+
+泛型、utility types 與 `satisfies` 只應解決可說明的資料關係。`import type` / `export type` 分清楚 runtime 與 compile-time import。不為「看起來進階」而新增型別技巧；不為尚未採用的套件預寫 module augmentation。
+
+Use generics, utility types, and `satisfies` only to solve a clear data relationship. Separate runtime and compile-time imports with `import type` / `export type`. Do not add type machinery for decoration, and do not write module augmentation for packages not in use.
+
+### 為什麼重要 / Why This Matters
+
+- **避免過度抽象**：型別越複雜，review 成本越高。
+- **保持真實**：規則只描述目前技術棧能驗證的做法。
+
+### Linus 哲學 / Linus Philosophy
+
+> Solve the real problem first; decide whether abstraction is warranted after.
+
+Good type machinery eliminates duplication and special cases. Bad type machinery turns error messages into another problem.
+
+### 檢查清單 / Checklist
+
+- [ ] 泛型用來保留輸入與輸出之間的型別關係。
+- [ ] `Pick`、`Omit`、`Partial` 只用在 derived type，不取代清楚的 domain model。
+- [ ] `satisfies` 用於 config、lookup map、variant map 等需要保留 literal inference 的地方。
+- [ ] type-only import/export 使用 `import type`、`export type`，避免混淆 runtime import。
+- [ ] module augmentation 只在套件已採用且有實際 extension point 時新增。
+
+### 範例 / Examples
+
+**不推薦 ❌ - 泛型沒有保留任何關係**:
+
+```typescript
+function wrap<T>(value: string): { value: string } {
+  return { value }
+}
+```
+
+**推薦 ✅ - 泛型保留輸入與輸出關係**:
+
+```typescript
+function wrap<T>(value: T): { value: T } {
+  return { value }
+}
+```
+
+**推薦 ✅ - type-only import/export**:
+
+```typescript
+import type { User } from './types'
+export type { User }
+```
+
+### 常見陷阱 / Common Pitfalls
+
+**陷阱: 用 `Partial` 讓必要欄位消失**
+
+```typescript
+// ❌ 呼叫端不知道哪些欄位真的存在
+function saveItem(item: Partial<Item>) {}
+
+// ✅ 新增和更新使用不同契約
+interface ItemUpdateInput { name?: string; price?: number }
+function updateItem(id: string, input: ItemUpdateInput): void {}
+```
+
+### 參考現有實作 / Reference Implementation
+
+- `apps/frontend/tailwind.config.ts` - `satisfies Config` 檢查 config 形狀。
+
+### 自動化 / Automation
+
+- **TypeScript**: `isolatedModules` 讓 type/value import 邊界更重要。
+- **ESLint**: `@typescript-eslint` 捕捉部分不安全模式。
+- **Manual Review**: 泛型和 utility types 是否真的降低重複或保留資料關係。
+
+---
+
+## 總結 / Summary
+
+TypeScript 的 4 條補充準則核心思想：
+
+1. **準則 TS-1**: 標注真正的邊界，推論處理細節。
+2. **準則 TS-2**: Runtime 邊界用 `unknown` + guard，不用 assertion 假裝安全。
+3. **準則 TS-3**: discriminated union 表達互斥狀態，消除 boolean 矛盾組合。
+4. **準則 TS-5**: 泛型與 `satisfies` 只服務真實資料關係。
+
+**Linus 哲學在 TypeScript 中的體現**:
+
+- **Good Taste** → TS-3（讓不可能狀態不可表示）
+- **Pragmatism** → TS-1、TS-5（只在真邊界加型別，不為語法本身加戲）
+- **Simplicity** → TS-2（邊界集中處理，核心保持乾淨）
+
+---
+
+## 術語備註 / Terminology Notes
+
+本文使用台灣前端社群常見譯法：`型別`、`型別推論`、`型別別名`、`聯合型別`、`泛型`、`型別守衛`、`型別收窄`。必要時保留英文原詞，避免硬翻造成溝通成本。
+
+---
+
+## 相關文檔 / Related Documents
+
+- [AGENTS.md](../../AGENTS.md) - Linus Torvalds 風格工程原則。
+- [README.md](README.md) - 準則總覽。
+- [06-collaboration.md](06-collaboration.md) - API adapter 與型別同步（準則 29）。
+- [TypeScript Handbook](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html) - 官方 TypeScript 基礎型別文件。
+- [TypeScript TSConfig Reference](https://www.typescriptlang.org/tsconfig/) - 官方 TSConfig 參考。
+
+---
+
+**最後更新 / Last Updated**: 2026-05-14  
+**維護者 / Maintainer**: Frontend Team

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/check-context.sh\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/atomic-design-convention/SKILL.md
+++ b/.claude/skills/atomic-design-convention/SKILL.md
@@ -1,0 +1,315 @@
+---
+name: atomic-design-convention
+description: |
+  Use when creating, placing, modifying, or reviewing React components in this codebase,
+  including Atomic Design layer decisions, atom-level implementation choices, naming,
+  imports, styling composition, and responsive behavior.
+---
+
+# Atomic Design Convention
+
+> This project uses Atomic Design Pattern paired with Next.js 15 App Router file structure.
+
+## Tech Stack
+
+- Next.js 15 (App Router)
+- React 19
+- TypeScript
+- Tailwind CSS
+- Radix UI + shadcn/ui
+
+## Full Project Structure
+
+```text
+apps/frontend/
+├── src/
+│   └── app/
+│       ├── components/                # Atomic Design components
+│       │   ├── atoms/                 # Atom components
+│       │   │   └── index.tsx          # Unified export
+│       │   ├── molecules/             # Molecule components
+│       │   │   └── index.tsx          # Unified export
+│       │   ├── organisms/             # Organism components
+│       │   │   └── index.tsx          # Unified export
+│       │   ├── templates/             # Template components (as needed)
+│       │   └── pages/                 # Page-level components (as needed)
+│       ├── hooks/                     # Reusable React Hooks
+│       ├── lib/                       # Utilities / API clients / strategy implementations
+│       ├── types/                     # TypeScript type definitions
+│       ├── fonts/                     # Font assets
+│       ├── product/                   # Feature route module
+│       ├── order/                     # Feature route module
+│       ├── customer/                  # Feature route module
+│       ├── report/                    # Feature route module
+│       ├── layout.tsx                 # Root layout
+│       ├── page.tsx                   # Home page
+│       └── globals.css                # Global styles
+├── public/                            # Static assets
+├── docs/                              # Project docs (human reference, not a dev dependency)
+├── .env.local                         # Environment variables (not committed)
+└── package.json
+```
+
+### Project-Specific Rules
+
+- Layer assignment for new components is based on **reusability + complexity**, not screen position.
+- Even when applying **compound component** patterns, all sub-components must remain within their correct atoms / molecules / organisms layer — do not merge layers for co-location convenience.
+- Feature route directories (`product/` / `order/` etc.): one `page.tsx` per route; dedicated `mock/` / `components/` subdirectories are allowed; shared logic goes back to `components/` / `hooks/` / `lib/` / `types/`.
+
+### Directory Organization
+
+#### Components Directory
+
+- **atoms/**: The most basic UI elements, cannot be broken down further
+  - One file per component; complex components can use a directory
+  - Must be exported from `index.tsx`
+
+- **molecules/**: Simple combinations of 2–5 atoms
+  - Organized into subdirectories by feature (e.g. `sidebar/`, `order/`)
+  - Must be exported from `index.tsx`
+
+- **organisms/**: Complex functional sections
+  - Can contain complex business logic
+  - Organized by feature module
+
+- **templates/** and **pages/**: Create as needed
+
+#### Feature Module Directories (product/, order/, etc.)
+
+- Follow Next.js App Router conventions
+- One `page.tsx` per route
+- Can include feature-specific subdirectories (e.g. `mock/`, `components/`)
+- Layouts use `layout.tsx`
+
+#### Shared Resource Directories
+
+- **hooks/**: Reusable React Hooks
+- **lib/**: Utilities, API clients, strategy patterns, etc.
+- **types/**: Shared TypeScript type definitions
+- **fonts/**: Custom font files
+
+---
+
+## Component Layer Definitions
+
+This project follows Atomic Design Pattern. Components are divided into five layers by complexity:
+
+### 1. Atoms
+
+**Definition**: The most basic, indivisible UI elements  
+**Location**: `src/app/components/atoms/`  
+**Examples**: Button, Input, Label, Badge, Avatar, Checkbox, Separator  
+**Rules**:
+
+- Single responsibility — does one thing
+- Highly reusable
+- Contains no business logic
+- Typically maps to a single HTML element or basic Radix UI component
+- Must be exported from `src/app/components/atoms/index.tsx`
+
+### 2. Molecules
+
+**Definition**: Simple component groups composed of multiple atoms  
+**Location**: `src/app/components/molecules/`  
+**Examples**: SearchBar (Input + Button), FormField (Label + Input), stockManageListItem  
+**Rules**:
+
+- Composed of 2–5 atoms
+- Begins to have simple interactive functionality
+- Can contain basic state management (useState)
+- Reference existing style: `src/app/components/molecules/stock/stockManageListItem.tsx`
+- Organized into subdirectories by feature (e.g. stock/, inventoryList/)
+- Must be exported from `src/app/components/molecules/index.tsx`
+
+### 3. Organisms
+
+**Definition**: More complex UI sections composed of molecules and atoms  
+**Location**: `src/app/components/organisms/` (create if needed)  
+**Examples**: Header, Sidebar, ProductTable, InventoryPanel  
+**Rules**:
+
+- Forms a distinct interface section
+- Can contain complex business logic
+- May need to receive API data or manage complex state
+- Has complete functionality
+
+### 4. Templates
+
+**Definition**: Layout components that define page structure  
+**Location**: `src/app/components/templates/` (create if needed)  
+**Examples**: DashboardLayout, ProductPageLayout  
+**Rules**:
+
+- Defines the overall structure and layout of a page
+- Uses slot/children pattern to place concrete content
+- Contains no concrete business data
+
+### 5. Pages
+
+**Definition**: Concrete page instances that combine templates and organisms  
+**Location**: `src/app/*/page.tsx` (Next.js App Router convention)  
+**Examples**: `src/app/product/add-product/page.tsx`, `src/app/product/inventory-list/page.tsx`  
+**Rules**:
+
+- Follows Next.js App Router file structure
+- Responsible for data fetching and page-level state management
+- Passes data down to child components
+
+---
+
+## General Component Development Rules
+
+- All components must use TypeScript with a complete Props interface
+- Use Tailwind CSS utility classes for styling
+- Follow the `className` naming patterns of existing components
+- Prefer Radix UI primitives (installed: dialog, select, checkbox, scroll-area, popover, tooltip, etc.)
+- Component filenames use camelCase (e.g. `button.tsx`, `stockManageListItem.tsx`)
+- Props interface naming format: `[ComponentName]Props`
+
+---
+
+## Atom Implementation Rules
+
+Use this section when creating, modifying, or reviewing reusable atom components under `apps/frontend/src/app/components/atoms/`.
+
+### Before Creating An Atom
+
+- Confirm the request is truly an atom, not a molecule or organism.
+- Inspect existing atoms first, especially `button.tsx`, `badge.tsx`, `input.tsx`, and Radix-backed primitives.
+- Prefer improving or composing an existing atom over creating a parallel primitive.
+- Keep atoms generic and UI-oriented. Do not add product IDs, inventory mutations, API calls, routing behavior, or other business logic.
+
+### Props And Types
+
+- Define an explicit `[ComponentName]Props` interface.
+- Use the narrowest practical React prop base:
+  - `React.ComponentProps<'button'>` for simple button-like atoms.
+  - `React.ComponentProps<'input'>` for simple input-like atoms.
+  - `React.ComponentPropsWithoutRef<typeof RadixPrimitive.Root>` for Radix-backed atoms.
+- Add `asChild?: boolean` only when polymorphic composition is useful and the existing pattern supports it.
+- Icon-only atoms must still expose accessible labels through props or composition.
+
+### Styling And Variants
+
+- Merge classes with `cn()` from `@/app/lib/utils`.
+- Accept consumer styling through `className`, and pass it last to `cn()` so callers can extend the atom safely.
+- Use semantic Tailwind tokens such as `bg-background`, `text-foreground`, `bg-primary`, `text-primary-foreground`, `border-input`, `text-muted-foreground`, `bg-destructive`, and `text-destructive-foreground`.
+- Use `class-variance-authority` (`cva`) only when the component has a real variant system. If there is only one visual style, keep classes inline and skip `cva`.
+- Use `lucide-react` for icons.
+
+### Radix, shadcn, And Next.js Boundaries
+
+- Prefer existing shadcn/Radix-backed atoms before writing custom markup.
+- Preserve Radix accessibility structure for overlays, menus, popovers, checkboxes, selects, tooltips, and dialogs.
+- Use `@radix-ui/react-slot` and `asChild` only when the component needs caller-controlled element composition.
+- Add `'use client'` only when the atom itself uses state, effects, event-only client APIs, or a Radix primitive that requires client execution.
+- Do not add Server Actions, Route Handlers, SSR data fetching, or `next/image` guidance unless the atom specifically handles that concern.
+
+### Export And Verification
+
+- Export shared atoms from `apps/frontend/src/app/components/atoms/index.tsx`.
+- Run `pnpm --filter frontend run type-check` after changing atom code.
+- Run `pnpm --filter frontend run lint` when the change touches lint-sensitive patterns or formatting.
+
+---
+
+## File Naming Convention
+
+```typescript
+// Component files
+productCard.tsx // ✅ Use camelCase
+ProductCard.tsx // ❌ Avoid PascalCase
+product-card.tsx // ❌ Avoid kebab-case
+
+// Hook files
+useProductList.ts // ✅ Prefix with use
+productListHook.ts // ❌
+
+// Type files
+product.ts // ✅ Concise name
+productTypes.ts // ❌ No Types suffix needed
+
+// Test files
+productCard.test.tsx // ✅
+productCard.spec.tsx // ✅
+```
+
+---
+
+## Import Path Convention
+
+```typescript
+// ✅ Use absolute paths (recommended)
+import { Button, Input } from '@/app/components/atoms'
+import { ProductCard } from '@/app/components/molecules'
+import type { Product } from '@/app/types/product'
+import { useAuth } from '@/app/hooks/useAuth'
+
+// ✅ Relative paths (same or child directory)
+import { ProductFilter } from './productFilter'
+import { helper } from '../utils'
+
+// ❌ Avoid complex relative paths
+import { Button } from '../../../components/atoms/button'
+```
+
+---
+
+## Component Composition Style Rules
+
+When developing components that will be composed together, consider the following styling rules:
+
+- **Border radius**:
+  - Avoid full border radius (`rounded-lg` etc.) on components that will be stacked
+  - Consider providing a `position` or `variant` prop to control which corners are rounded
+  - Example: `position="first" | "middle" | "last" | "single"`
+
+- **Border control**:
+  - Stacked components should avoid setting full borders; let the container manage them
+  - Or provide a `showBorder` prop to let the parent control it
+
+- **External spacing**:
+  - Components themselves should avoid setting external margin
+  - Let the parent use gap, space-y/x, etc. to control spacing
+  - Internal padding is managed by the component itself
+
+```tsx
+// Composable component design
+interface ListItemProps {
+  position?: 'first' | 'middle' | 'last' | 'single'
+  // ... other props
+}
+
+const getRoundedClass = (position?: string) => {
+  switch (position) {
+    case 'first':
+      return 'rounded-t-lg'
+    case 'last':
+      return 'rounded-b-lg'
+    case 'single':
+      return 'rounded-lg'
+    default:
+      return '' // middle needs no border radius
+  }
+}
+```
+
+---
+
+## Component Selection Guide
+
+When creating a new component, decide which layer it belongs to:
+
+- Only one element? → **Atoms**
+- Simple combination of 2–5 elements? → **Molecules**
+- Complex functional section? → **Organisms**
+- Layout frame for an entire page? → **Templates**
+- A complete page? → **Pages** (Next.js App Router `page.tsx`)
+
+---
+
+## Responsive Design
+
+- Use Tailwind responsive prefixes: `sm:` `md:` `lg:` `xl:` `2xl:`
+- Mobile-first design principle
+- Reference existing pages for responsive handling patterns

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,110 @@
+# AGENTS.md
+
+## Project Working Principles
+
+### Linus Torvalds-Inspired Development Philosophy
+
+Use this section as a practical engineering standard for the POS project. It is
+inspired by Linus Torvalds' public engineering preferences in Linux and Git:
+simple core ideas, reviewable patches, fast feedback, and long-term
+maintainability. Keep the technical rigor; do not copy abusive communication.
+
+#### 1. Solve a Real Problem
+
+- Every change must start from a concrete problem, user impact, bug, or
+  maintainability cost.
+- Do not add abstractions, frameworks, dependencies, or configuration until the
+  current code shows a real need.
+- If the change is an optimization, include numbers or a clear before/after
+  observation. Also document the trade-off.
+
+#### 2. Make the Code Reviewable
+
+- Prefer small, logical changes that can be understood and verified on their
+  own.
+- Separate bug fixes, refactors, formatting, file moves, and feature work into
+  different commits or pull requests when they are not the same logical change.
+- A reviewer should be able to answer: what problem is solved, why this shape,
+  how it was verified, and what risk remains.
+- Keep commit messages and PR descriptions self-contained. Do not require
+  reviewers to reconstruct the reason from chat history.
+
+#### 3. Keep the Core Simple
+
+- Design the data model and boundaries first. Good structure makes the code
+  smaller, easier to test, and less fragile.
+- Prefer clear invariants over clever control flow.
+- Push incidental complexity to edges such as adapters, parsing, UI state, or
+  integration glue instead of letting it leak through the domain model.
+- If a file or function becomes hard to explain in one paragraph, split the
+  responsibility.
+
+#### 4. Maintainability Beats Cleverness
+
+- Write short, focused functions that do one thing well.
+- Keep nesting shallow. Deep indentation is usually a design smell.
+- Avoid tricky expressions, hidden side effects, and multiple unrelated actions
+  on one line.
+- Use names that make the important concept obvious. Local temporary names may
+  be short; exported or shared names must be descriptive.
+- Comments should explain intent, constraints, or surprising trade-offs. Do not
+  use comments to compensate for confusing code.
+
+#### 5. Fast Feedback Is a Feature
+
+- Prefer workflows that make mistakes visible quickly: type checks, focused
+  tests, linting, local builds, and small PRs.
+- Keep tools and scripts predictable. A slow or flaky verification step is an
+  engineering problem, not just an inconvenience.
+- When adding tests, make them narrow enough to diagnose the issue and broad
+  enough to protect the behavior that matters.
+
+#### 6. Preserve Bisectability
+
+- Each commit should leave the project in a coherent state whenever practical.
+- Avoid commits that temporarily break build, type check, routing, migrations,
+  or generated artifacts.
+- If a series has dependencies, state the order and reason clearly.
+
+#### 7. Be Direct, Technical, and Respectful
+
+- Review code, behavior, and trade-offs. Do not review people.
+- Be blunt about correctness, security, data loss, user impact, and maintenance
+  risk, but keep feedback specific and actionable.
+- If rejecting an approach, explain the invariant or project constraint it
+  violates and suggest the smaller path forward.
+
+### POS Project Application Checklist
+
+Before changing code:
+
+- State the problem in one sentence.
+- Identify the smallest logical change that solves it.
+- Check whether the existing architecture already has a pattern for it.
+- Decide what evidence will prove the change works.
+
+While changing code:
+
+- Keep the data flow explicit.
+- Avoid unrelated cleanup.
+- Prefer boring, readable code over clever compression.
+- Update documentation when behavior, setup, or workflow changes.
+
+Before handing off:
+
+- Run the relevant verification command.
+- Review the diff as if you were the maintainer receiving it.
+- Ensure the PR or commit message explains the problem, the solution, and the
+  verification.
+
+### Reference Anchors
+
+- Linux kernel coding style: simplicity, short functions, shallow nesting, and
+  comments that explain intent instead of confusing code.
+  https://kernel.org/doc/html/next/process/coding-style.html
+- Linux kernel patch submission guidance: describe the problem, user-visible
+  impact, trade-offs, and keep each patch to one logical change.
+  https://kernel.org/doc/html/next/process/submitting-patches.html
+- Git 20-year Q&A with Linus Torvalds: Git's design emphasized performance,
+  distributed workflow, corruption detection, and a simple low-level model.
+  https://github.blog/open-source/git/git-turns-20-a-qa-with-linus-torvalds/

--- a/apps/frontend/CLAUDE.md
+++ b/apps/frontend/CLAUDE.md
@@ -1,980 +1,113 @@
-# 專案開發規範
+# 前端開發入口
 
-## 技術棧
+固定載入的前端索引；詳細規則在 `.claude/rules`、`.claude/hooks` 與 `.claude/skills`。
 
-- Next.js 15 (App Router)
-- React 19
-- TypeScript
-- Tailwind CSS
-- Radix UI + shadcn/ui 組件系統
+## 架構概覽
 
-## 專案結構
+| 面向 | 決策 |
+| --- | --- |
+| 前端框架 | Next.js 15 App Router / React 19 |
+| 語言 | TypeScript |
+| UI | Radix/shadcn-style atoms、Tailwind CSS、`lucide-react` |
+| 資料邊界 | 目前沒有集中 API client；資料轉換放在 `lib/`、`hooks/` 或路由邊界 |
+| 狀態 | React local state 與 custom hooks；未導入全域 store 或 TanStack Query |
+| 路由 | Next.js App Router |
+| Locales | 目前未導入 i18n |
 
-```
+## 必讀來源
+
+- `AGENTS.md`：POS 專案工程原則。
+- `.claude/rules/README.md`：前端規則總覽。
+- `.claude/rules/typescript.md`：TypeScript 補充規則。
+- `.claude/skills/atomic-design-convention/SKILL.md`：建立、放置、修改或審查 React 元件時使用。
+- `.claude/hooks/README.md`：hook 觸發與驗證說明。
+- `apps/frontend/docs/design-index.md`：UI 設計參考入口。
+- `apps/frontend/docs/AI_CODE_REVIEW.md`：程式碼審查參考。
+- `apps/frontend/docs/README.md`：Practical UI PDF 的可選設定；不要假設 PDF 一定存在。
+
+## 前端專案地圖
+
+```text
 apps/frontend/
-├── src/
-│   └── app/
-│       ├── components/          # UI 組件（Atomic Design）
-│       │   ├── atoms/          # 原子組件：Button, Input, Label 等
-│       │   │   ├── button/
-│       │   │   ├── input.tsx
-│       │   │   └── index.tsx   # 統一導出
-│       │   ├── molecules/      # 分子組件：SearchBar, FormField 等
-│       │   │   ├── sidebar/
-│       │   │   ├── order/
-│       │   │   ├── stock/
-│       │   │   ├── inventoryList/
-│       │   │   ├── addProduct/
-│       │   │   ├── chart/
-│       │   │   ├── dragAndDrop/
-│       │   │   └── index.tsx
-│       │   ├── organisms/      # 有機體組件：Header, Sidebar 等
-│       │   │   ├── sidebar/
-│       │   │   ├── chart/
-│       │   │   ├── dragAndDrop/
-│       │   │   └── index.tsx
-│       │   ├── templates/      # 模板組件（如需要）
-│       │   └── pages/          # 頁面級組件（如需要）
-│       │
-│       ├── hooks/              # 自定義 React Hooks
-│       │   ├── useFetch.ts
-│       │   └── useAuth.ts
-│       │
-│       ├── lib/                # 工具函數和輔助模組
-│       │   ├── utils.ts        # 通用工具函數
-│       │   ├── strategies/     # 策略模式實現
-│       │   └── api.ts          # API 相關函數
-│       │
-│       ├── types/              # TypeScript 類型定義
-│       │   ├── inventoryList.ts
-│       │   ├── product.ts
-│       │   └── user.ts
-│       │
-│       ├── fonts/              # 自定義字體文件
-│       │
-│       ├── product/            # 產品功能模組
-│       │   ├── add-product/
-│       │   │   └── page.tsx
-│       │   ├── inventory-list/
-│       │   │   ├── page.tsx
-│       │   │   └── mock/       # 模擬數據
-│       │   └── category-management/
-│       │       └── page.tsx
-│       │
-│       ├── order/              # 訂單功能模組
-│       │   ├── all-orders/
-│       │   │   └── page.tsx
-│       │   └── create-order/
-│       │       └── page.tsx
-│       │
-│       ├── customer/           # 客戶功能模組
-│       │   └── page.tsx
-│       │
-│       ├── report/             # 報表功能模組
-│       │   └── page.tsx
-│       │
-│       ├── layout.tsx          # 根佈局
-│       ├── page.tsx            # 首頁
-│       └── globals.css         # 全局樣式
-│
-├── public/                     # 靜態資源
-│   ├── images/
-│   └── icons/
-│
-├── docs/                       # 專案文檔
-│   ├── Practical-UI.pdf
-│   └── design-index.md
-│
-├── .env.local                  # 環境變數（不提交到 git）
-├── .gitignore
+├── src/app/
+│   ├── components/        # atoms, molecules, organisms, templates, pages
+│   ├── hooks/             # reusable React hooks
+│   ├── lib/               # utils, strategies, data transforms
+│   ├── types/             # shared TypeScript types
+│   ├── product/           # product routes
+│   ├── order/             # order routes
+│   ├── customer/          # customer routes
+│   ├── report/            # report routes
+│   ├── layout.tsx
+│   ├── page.tsx
+│   └── globals.css
+├── docs/
+├── public/
 ├── package.json
 ├── tsconfig.json
 ├── tailwind.config.ts
-├── next.config.js
-├── CLAUDE.md                   # AI 開發規範（本文件）
-└── AI_CODE_REVIEW.md          # AI Code Review 規範
+└── next.config.ts
 ```
 
-### 目錄組織原則
-
-#### 📁 Components（組件目錄）
-- **atoms/**：最基礎的 UI 元素，不可再分割
-  - 每個組件一個檔案，複雜組件可使用目錄
-  - 必須在 `index.tsx` 統一導出
-
-- **molecules/**：2-5 個 atoms 組成的簡單組合
-  - 按功能分類放在子目錄（如 `sidebar/`, `order/`）
-  - 必須在 `index.tsx` 統一導出
-
-- **organisms/**：複雜的功能區塊
-  - 可包含複雜業務邏輯
-  - 按功能模組組織
-
-- **templates/** 和 **pages/**：根據需要建立
-
-#### 📁 功能模組目錄（product/, order/ 等）
-- 遵循 Next.js App Router 規範
-- 每個路由一個 `page.tsx`
-- 可包含功能專屬的子目錄（如 `mock/`, `components/`）
-- 佈局使用 `layout.tsx`
-
-#### 📁 共用資源目錄
-- **hooks/**：可重用的 React Hooks
-- **lib/**：工具函數、API 客戶端、策略模式等
-- **types/**：共用的 TypeScript 類型定義
-- **fonts/**：自定義字體文件
-
-### 檔案命名規範
-
-```typescript
-// 組件文件
-productCard.tsx              // ✅ 使用 camelCase
-ProductCard.tsx              // ❌ 避免 PascalCase
-product-card.tsx             // ❌ 避免 kebab-case
-
-// Hook 文件
-useProductList.ts            // ✅ 以 use 開頭
-productListHook.ts           // ❌
-
-// 類型文件
-product.ts                   // ✅ 簡潔命名
-productTypes.ts              // ❌ 不需要 Types 後綴
-
-// 測試文件
-productCard.test.tsx         // ✅
-productCard.spec.tsx         // ✅
-```
-
-### Import 路徑規範
-
-```typescript
-// ✅ 使用絕對路徑（推薦）
-import { Button, Input } from '@/app/components/atoms'
-import { ProductCard } from '@/app/components/molecules'
-import type { Product } from '@/app/types/product'
-import { useAuth } from '@/app/hooks/useAuth'
-
-// ✅ 相對路徑（同目錄或子目錄）
-import { ProductFilter } from './productFilter'
-import { helper } from '../utils'
-
-// ❌ 避免複雜的相對路徑
-import { Button } from '../../../components/atoms/button'
-```
-
-## Code Review 規範
-
-**完整規範文件**：@AI_CODE_REVIEW.md
-
-所有提交的代碼都應該遵循 AI Code Review 規範，確保代碼品質、類型安全、性能優化和安全性。
-
-### Code Review 重點檢查項目
-
-#### Critical（必須檢查）
-
-- ❌ **禁止使用 `any` 類型**：所有變數、函數參數、useState 都必須有明確類型
-- ❌ **禁止使用 `@ts-ignore`**：不允許忽略 TypeScript 錯誤
-- ⚠️ **useEffect 依賴完整**：所有外部變數都必須在依賴數組中
-- ⚠️ **副作用清理**：所有 timer、listener、subscription 都必須清理
-- 🔒 **無硬編碼密鑰**：使用環境變數管理敏感資訊
-
-#### Important（應該檢查）
-
-- 📦 **組件大小**：單個組件不超過 200 行，遵循單一職責
-- 🎯 **Props 設計**：Props 不超過 7 個，提供預設值
-- ⚡ **性能基本要求**：列表項有唯一 key、大列表分頁、圖片使用 Next.js Image
-- ⚠️ **避免過早優化**：不要預設使用 memo/useCallback/useMemo，除非有實測性能問題
-- 🎨 **使用 Tailwind CSS**：禁止內聯樣式和 CSS-in-JS
-- ♿ **可訪問性**：按鈕有 aria-label、圖片有 alt、表單有 label
-
-#### Nice to have（建議檢查）
-
-- 💅 **命名規範**：組件 PascalCase、函數 camelCase、布林值 is/has 前綴
-- 🧹 **代碼整潔**：移除 console.log、註解代碼、未處理的 TODO
-- 📝 **測試覆蓋**：新組件有測試，覆蓋率 > 70%
-
-詳細檢查清單和範例請參考：@AI_CODE_REVIEW.md
-
-## UI 設計規範
-
-**主要設計參考**：@docs/Practical-UI-2nd-edition.pdf *(需額外取得，見 @docs/README.md)*
-**設計索引**：@docs/design-index.md *(必讀，包含完整索引)*
-
-> ⚠️ **重要說明**：
-> Practical-UI-2nd-edition.pdf（第二版）因版權和檔案大小（166MB）原因未包含在版本控制中。
-> 團隊成員請參考 @docs/README.md 了解如何向版權人索取並放置此文件。
->
-> **沒有 PDF 也能開發**：`design-index.md` 已包含主要設計原則摘要。
-
-所有 UI 組件的設計、佈局、顏色、間距、字體等視覺規範，都應參考 Practical UI 設計文件。
-
-### 設計原則
-
-- 設計前先查閱 @docs/design-index.md 找到相關章節
-- 遵循以下核心原則：
-  - **極簡主義**：移除不必要的元素，降低認知負荷
-  - **一致性**：保持視覺和互動的一致性
-  - **可訪問性**：確保介面對所有使用者可用
-  - **清晰層級**：使用色彩、間距、字體建立清晰的視覺層級
-
-### 組件組合 UI 處理原則
-
-當組件需要組合使用時（特別是垂直或水平堆疊），必須注意以下原則：
-
-#### 1. 圓角處理（Border Radius）
-
-- **問題**：組件上下組合時，如果每個組件都設置完整的四邊圓角，會造成視覺斷層
-- **解決方案**：
-  - 由外層 container 統一處理圓角
-  - 堆疊組件中，只有首尾元素需要對應方向的圓角
-  - 中間元素不需要圓角
-- **範例**：
-
-  ```tsx
-  // ❌ 錯誤：每個項目都有圓角
-  <div className="rounded-lg">Item 1</div>
-  <div className="rounded-lg">Item 2</div>
-  <div className="rounded-lg">Item 3</div>
-
-  // ✅ 正確：由容器統一處理，或首尾分別處理
-  <div className="rounded-lg overflow-hidden">
-    <div>Item 1</div>
-    <div>Item 2</div>
-    <div>Item 3</div>
-  </div>
-
-  // ✅ 或者：首尾元素個別處理
-  <div className="rounded-t-lg">Item 1</div>
-  <div>Item 2</div>
-  <div className="rounded-b-lg">Item 3</div>
-  ```
-
-#### 2. 邊框處理（Border）
-
-- **問題**：組合組件時邊框可能重疊，造成加粗效果
-- **解決方案**：
-  - 統一由外層 container 處理邊框
-  - 或使用 `border-t-0` 等工具類移除內部重疊邊框
-  - 中間元素只保留必要的分隔線
-
-#### 3. 間距處理（Spacing）
-
-- **問題**：每個組件各自設置 padding/margin 會造成間距不一致
-- **解決方案**：
-  - 容器使用統一的 gap 或 space-y 控制元素間距
-  - 內部組件避免設置外部 margin
-  - Padding 由各組件內部自行管理
-
-#### 4. 背景色與層次
-
-- **問題**：組合時背景色重疊可能造成視覺混亂
-- **解決方案**：
-  - 明確定義容器和內容的背景層次
-  - 注意對比度，確保可讀性
-  - 使用一致的色彩深度系統
-
-### 關鍵設計規範快速參考
-
-> 以下頁碼參考自 Practical-UI-2nd-edition.pdf（如可用）。詳細內容請參考 @docs/design-index.md
-
-- **基礎原則**：第 1 章 (頁 16-53)（建立設計系統、保持一致性、可訪問性、互動狀態）
-- **極簡主義**：第 2 章 (頁 55-76)（移除不必要元素、漸進式揭露、減少選擇）
-- **色彩系統**：第 3 章 (頁 78-161)（對比度、品牌色、透明色彩、調色板規則）
-- **佈局間距**：第 4 章 (頁 163-227)（12 欄網格、間距系統、視覺層級、留白）
-- **字體排版**：第 5 章 (頁 229-264)（字體選擇、字級比例、行高、對齊）
-- **文案撰寫**：第 6 章 (頁 266-293)（簡潔、一致用詞、句首大寫、錯誤訊息）
-- **按鈕設計**：第 7 章 (頁 295-328)（三級權重、左對齊、點擊目標大小）
-- **表單設計**：第 8 章 (頁 330-369)（單欄佈局、欄位標籤、驗證方式）
-
-### 設計工作流程
-
-1. 確認要設計的組件類型（Atom/Molecule/Organism）
-2. **必須**查閱 @docs/design-index.md 找到相關設計規範章節
-3. 如有 Practical-UI.pdf，可參考對應頁碼獲得更詳細說明
-4. 如設計規範不明確，應詢問使用者確認
-5. 確保最終設計符合專案的視覺一致性
-
-## UI 組件開發（Atomic Design Pattern）
-
-### 組件架構層級
-
-本專案遵循 Atomic Design Pattern，組件依複雜度分為五個層級：
-
-#### 1. Atoms（原子）
-
-**定義**：最基礎、不可再分割的 UI 元素
-**位置**：@src/app/components/atoms/
-**範例**：Button, Input, Label, Badge, Avatar, Checkbox, Separator
-**規則**：
-
-- 單一職責，只做一件事
-- 高度可重用
-- 不包含業務邏輯
-- 通常對應單一 HTML 元素或基礎 Radix UI 組件
-- 必須在 @src/app/components/atoms/index.tsx 中 export
-
-#### 2. Molecules（分子）
-
-**定義**：由多個 Atoms 組成的簡單組件群組
-**位置**：@src/app/components/molecules/
-**範例**：SearchBar (Input + Button), FormField (Label + Input), stockManageListItem
-**規則**：
-
-- 由 2-5 個 Atoms 組合而成
-- 開始具有簡單的互動功能
-- 可包含基礎的狀態管理（useState）
-- 參考現有風格：@src/app/components/molecules/stock/stockManageListItem.tsx
-- 按功能分類放在子目錄（如 stock/, inventoryList/）
-- 必須在 @src/app/components/molecules/index.tsx 中 export
-
-#### 3. Organisms（有機體）
-
-**定義**：由 Molecules 和 Atoms 組成的較複雜 UI 區塊
-**位置**：@src/app/components/organisms/（如需要可建立）
-**範例**：Header, Sidebar, ProductTable, InventoryPanel
-**規則**：
-
-- 形成明確的介面區域
-- 可包含複雜的業務邏輯
-- 可能需要接收 API 資料或管理複雜狀態
-- 具有完整的功能性
-
-#### 4. Templates（模板）
-
-**定義**：定義頁面結構的佈局組件
-**位置**：@src/app/components/templates/（如需要可建立）
-**範例**：DashboardLayout, ProductPageLayout
-**規則**：
-
-- 定義頁面的整體結構和佈局
-- 使用 slot/children pattern 來放置具體內容
-- 不包含具體的業務資料
-
-#### 5. Pages（頁面）
-
-**定義**：具體的頁面實例，組合 Templates 和 Organisms
-**位置**：@src/app/\*/page.tsx（Next.js App Router 規範）
-**範例**：@src/app/product/add-product/page.tsx, @src/app/product/inventory-list/page.tsx
-**規則**：
-
-- 遵循 Next.js App Router 的檔案結構
-- 負責資料獲取和頁面級狀態管理
-- 將資料傳遞給下層組件
-
-### 組件開發通用規則
-
-- 所有組件必須使用 TypeScript，定義完整的 Props interface
-- 使用 Tailwind CSS utility classes 進行樣式設計
-- 遵循現有組件的 className 命名模式
-- 優先使用 Radix UI 底層組件（已安裝：dialog, select, checkbox, scroll-area, popover, tooltip 等）
-- 組件檔案命名使用 camelCase（如 `button.tsx`, `stockManageListItem.tsx`）
-- Props interface 命名格式：`[ComponentName]Props`
-
-#### 組件組合樣式規則
-
-開發會被組合使用的組件時，必須考慮以下樣式處理：
-
-- **圓角設計**：
-
-  - 避免在會被堆疊的組件上設置完整圓角（`rounded-lg` 等）
-  - 考慮提供 `position` 或 `variant` prop 來控制圓角位置
-  - 範例：`position="first" | "middle" | "last" | "single"`
-
-- **邊框控制**：
-
-  - 堆疊組件應避免設置完整邊框，改由容器統一管理
-  - 或提供 `showBorder` 等 prop 讓父組件控制
-
-- **外部間距**：
-
-  - 組件本身避免設置外部 margin
-  - 讓父組件使用 gap、space-y/x 等工具類控制間距
-  - 內部 padding 由組件自行管理
-
-- **參考範例**：
-
-  ```tsx
-  // 可組合的組件設計
-  interface ListItemProps {
-    position?: 'first' | 'middle' | 'last' | 'single'
-    // ... other props
-  }
-
-  const getRoundedClass = (position?: string) => {
-    switch (position) {
-      case 'first':
-        return 'rounded-t-lg'
-      case 'last':
-        return 'rounded-b-lg'
-      case 'single':
-        return 'rounded-lg'
-      default:
-        return '' // middle 不需要圓角
-    }
-  }
-  ```
-
-### React Hooks 使用規範 ⚠️
-
-#### useEffect 依賴管理
-```typescript
-// ❌ 缺少依賴
-useEffect(() => {
-  fetchData(userId)
-}, []) // Missing: userId
-
-// ✅ 完整依賴
-useEffect(() => {
-  fetchData(userId)
-}, [userId])
-
-// ✅ 依賴過多時拆分為多個 useEffect
-useEffect(() => {
-  fetchUserData()
-}, [userId])
-
-useEffect(() => {
-  fetchProductData()
-}, [productId])
-```
-
-#### 副作用清理（重要！）
-```typescript
-// ❌ 未清理副作用
-useEffect(() => {
-  const interval = setInterval(() => updateData(), 1000)
-  window.addEventListener('resize', handleResize)
-}, [])
-
-// ✅ 正確清理
-useEffect(() => {
-  const interval = setInterval(() => updateData(), 1000)
-  const handleResize = () => { /* ... */ }
-  window.addEventListener('resize', handleResize)
-
-  return () => {
-    clearInterval(interval)
-    window.removeEventListener('resize', handleResize)
-  }
-}, [])
-
-// ✅ 處理異步操作的組件卸載
-useEffect(() => {
-  let isMounted = true
-
-  fetchData().then((data) => {
-    if (isMounted) setState(data)
-  })
-
-  return () => { isMounted = false }
-}, [])
-```
-
-#### 避免不必要的 State
-```typescript
-// ❌ 可以從其他 state 計算得出
-const [data, setData] = useState<Item[]>([])
-const [count, setCount] = useState(0)
-const [isEmpty, setIsEmpty] = useState(true)
-
-useEffect(() => {
-  setCount(data.length)
-  setIsEmpty(data.length === 0)
-}, [data])
-
-// ✅ 使用派生狀態
-const [data, setData] = useState<Item[]>([])
-const count = data.length
-const isEmpty = data.length === 0
-```
-
-#### 檢查清單
-- [ ] useEffect 依賴數組包含所有外部變數
-- [ ] 所有 timer、listener、subscription 都有清理
-- [ ] 避免可以通過計算得出的 State
-- [ ] 異步操作檢查組件是否已卸載
-
-### 性能優化規範 ⚡
-
-#### ⚠️ 核心原則：不要過早優化
-
-**重要**：只在有**實測性能問題**時才進行優化。過早優化會降低代碼可讀性和維護性。
-
-**React 官方建議**：
-> "You don't need to wrap every function in useCallback. If your component doesn't have performance problems, you don't need to memoize anything."
-
----
-
-#### React.memo 使用時機
-
-**只在以下情況使用**：
-1. 組件渲染成本高（大量 DOM、複雜計算）
-2. props 不常變化
-3. 有實測的性能問題
-
-```typescript
-// ✅ 應該使用：列表項組件
-export const ProductCard = memo(function ProductCard({ product }: { product: Product }) {
-  // 組件會被渲染很多次，且 product 不常變
-  return <div>{product.name}</div>
-})
-
-// ❌ 不需要使用：簡單組件
-export function SimpleButton({ onClick, label }: ButtonProps) {
-  // 組件很簡單，不需要 memo
-  return <button onClick={onClick}>{label}</button>
-}
-```
-
----
-
-#### useCallback 使用時機
-
-**只在以下情況使用**：
-1. ✅ 傳給使用了 `React.memo` 的子組件
-2. ✅ 函數在 `useEffect` / `useMemo` / `useCallback` 的依賴數組中
-3. ✅ 函數創建成本很高（包含複雜計算）
-
-```typescript
-// ✅ 正確使用：子組件有 memo
-const MemoChild = memo(function Child({ onClick }) {
-  return <button onClick={onClick}>Click</button>
-})
-
-function Parent() {
-  const handleClick = useCallback(() => {
-    console.log('clicked')
-  }, [])
-
-  return <MemoChild onClick={handleClick} />  // ← 子組件有 memo
-}
-
-// ❌ 錯誤使用：子組件沒有 memo
-function RegularChild({ onClick }) {  // ← 沒有 memo
-  return <button onClick={onClick}>Click</button>
-}
-
-function Parent() {
-  const handleClick = useCallback(() => {  // ← 沒有意義！
-    console.log('clicked')
-  }, [])
-
-  return <RegularChild onClick={handleClick} />
-}
-
-// ✅ 正確做法：不使用 useCallback
-function Parent() {
-  const handleClick = () => {  // ← 簡單清晰
-    console.log('clicked')
-  }
-
-  return <RegularChild onClick={handleClick} />
-}
-```
-
----
-
-#### useMemo 使用時機
-
-**只在以下情況使用**：
-1. ✅ 計算成本很高（排序、過濾大量數據、複雜運算）
-2. ✅ 傳給使用了 `React.memo` 的子組件（穩定引用）
-3. ✅ 在依賴數組中使用
-
-```typescript
-// ✅ 正確使用：昂貴的計算
-const sortedProducts = useMemo(
-  () => products.sort((a, b) => b.price - a.price),  // 排序成本高
-  [products]
-)
-
-// ❌ 錯誤使用：簡單的計算
-const total = useMemo(() => a + b, [a, b])  // ← 沒必要
-const total = a + b  // ← 直接計算更好
-
-// ✅ 正確使用：穩定對象引用（配合 memo）
-const MemoChild = memo(function Child({ config }) { ... })
-
-function Parent() {
-  const config = useMemo(() => ({ theme: 'dark', size: 'large' }), [])
-  return <MemoChild config={config} />  // ← 子組件有 memo
-}
-
-// ❌ 錯誤使用：子組件沒有 memo
-function RegularChild({ config }) { ... }  // ← 沒有 memo
-
-function Parent() {
-  const config = useMemo(() => ({ theme: 'dark' }), [])  // ← 沒有意義！
-  return <RegularChild config={config} />
-}
-```
-
----
-
-#### 列表渲染優化
-
-```typescript
-// ✅ 使用唯一 ID 作為 key
-products.map(product => (
-  <ProductCard key={product.id} product={product} />  // ← 使用 id，不是 index
-))
-
-// ✅ 大列表使用分頁（超過 50 項）
-const [page, setPage] = useState(1)
-const pageSize = 20
-const paginatedProducts = useMemo(
-  () => products.slice((page - 1) * pageSize, page * pageSize),
-  [products, page]
-)
-
-// ✅ 列表項使用 memo（如果渲染成本高）
-const ProductCard = memo(function ProductCard({ product }) {
-  return <div>{product.name}</div>
-})
-```
-
----
-
-#### 圖片優化
-
-```typescript
-// ✅ 使用 Next.js Image 組件
-import Image from 'next/image'
-
-<Image
-  src="/product.jpg"
-  width={800}
-  height={600}
-  alt="Product"
-  priority  // 首屏圖片使用 priority
-/>
-
-// ✅ 響應式圖片
-<Image
-  src="/image.jpg"
-  width={800}
-  height={600}
-  alt="Product"
-  sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
-/>
-```
-
----
-
-#### 性能優化檢查清單
-
-**在添加優化之前，先問自己**：
-- [ ] 是否有實測的性能問題？（使用 React DevTools Profiler）
-- [ ] 子組件是否使用了 `React.memo`？（useCallback/useMemo 的前提）
-- [ ] 計算是否真的昂貴？（> 10ms？）
-- [ ] 優化後是否真的有改善？（再次測量）
-
-**基本要求**（無需優化）：
-- [ ] 列表項有唯一 key（使用 ID 而非 index）
-- [ ] 大列表使用分頁（超過 50 項）
-- [ ] 所有圖片使用 Next.js `Image` 組件
-
-**性能優化**（只在有問題時）：
-- [ ] 列表項組件使用 `React.memo`（如果渲染成本高）
-- [ ] 父組件的回調使用 `useCallback`（**前提**：子組件有 memo）
-- [ ] 父組件的物件/陣列使用 `useMemo`（**前提**：子組件有 memo）
-
-**記住**：
-- ✅ 清晰的代碼 > 過度優化的代碼
-- ✅ 可讀性優先，性能其次（除非有問題）
-- ✅ 先測量，再優化，後驗證
-- ❌ 不要為了「最佳實踐」而優化
-
-詳細範例請參考：@AI_CODE_REVIEW.md 第 3、5 章
-
-### 組件選擇指南
-
-建立新組件時，判斷應該放在哪一層：
-
-- 只有一個元素？ → Atoms
-- 2-5 個元素的簡單組合？ → Molecules
-- 複雜的功能區塊？ → Organisms
-- 整個頁面的佈局框架？ → Templates
-- 完整的頁面？ → Pages
-
-### 響應式設計
-
-- 使用 Tailwind 的響應式前綴：sm: md: lg: xl: 2xl:
-- 移動優先（mobile-first）設計原則
-- 參考現有頁面的響應式處理方式
-
-## 頁面開發
-
-### 產品相關頁面
-
-- 新增產品頁面：@src/app/product/add-product/page.tsx
-- 庫存列表頁面：@src/app/product/inventory-list/page.tsx
-- 遵循 Next.js App Router 的檔案結構規範
-
-## TypeScript 類型定義
-
-### 類型管理
-
-- 所有類型定義放在 @src/app/types/ 目錄
-- 參考現有類型結構：@src/app/types/inventoryList.ts
-- 使用 interface 而非 type（除非有特殊需求）
-
-### 類型安全規範 ⚠️
-
-#### 嚴格禁止項目
-```typescript
-// ❌ 禁止使用 any
-const data: any = fetchData()
-const handleClick = (event: any) => {}
-
-// ❌ 禁止使用 @ts-ignore 或 @ts-expect-error
-// @ts-ignore
-const result = someFunction()
-
-// ❌ 空陣列/物件沒有類型註解
-const [items, setItems] = useState([])
-const [user, setUser] = useState({})
-```
-
-#### 正確做法
-```typescript
-// ✅ 明確定義類型
-interface Product {
-  id: number
-  name: string
-  price: number
-}
-
-// ✅ useState 提供泛型類型
-const [items, setItems] = useState<Product[]>([])
-const [user, setUser] = useState<User | null>(null)
-
-// ✅ 使用具體的事件類型
-const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {}
-const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {}
-
-// ✅ 使用類型守衛代替類型斷言
-function isProduct(data: unknown): data is Product {
-  return (
-    typeof data === 'object' &&
-    data !== null &&
-    'id' in data &&
-    'name' in data
-  )
-}
-
-if (isProduct(data)) {
-  console.log(data.name) // 類型安全
-}
-```
-
-#### 類型檢查清單
-- [ ] 代碼中不存在 `any` 類型
-- [ ] 所有 `useState` 都有泛型類型註解
-- [ ] Props interface 完整定義
-- [ ] 避免使用 `as` 斷言，優先使用類型守衛
-- [ ] 不使用 `@ts-ignore` 或 `@ts-expect-error`
-- [ ] 所有函數參數和返回值都有類型註解
-
-詳細範例請參考：@AI_CODE_REVIEW.md 第 2 章
-
-## 程式碼品質
-
-### 開發指令
-
-- 開發環境：`npm run dev`
-- 型別檢查：`npm run type-check`
-- Lint 檢查：`npm run lint`
-- 格式化：`npm run format`
-- 建置專案：`npm run build`
-
-### 程式碼風格
-
-- 使用 ESLint + Prettier 自動格式化
-- commit 前會自動執行 lint-staged
-- 遵循專案既有的程式碼風格
-
-### 命名規範 📝
-
-```typescript
-// ✅ 組件使用 PascalCase
-function ProductCard() {}
-function ProductList() {}
-
-// ✅ 函數和變數使用 camelCase
-const handleSubmit = () => {}
-const productList: Product[] = []
-
-// ✅ 布林值使用 is/has/should 前綴
-const isLoggedIn = true
-const hasPermission = false
-const shouldShowModal = false
-
-// ✅ 常量使用 UPPER_SNAKE_CASE
-const MAX_ITEMS = 100
-const API_BASE_URL = 'https://api.example.com'
-
-// ✅ 私有屬性使用底線前綴
-const _privateMethod = () => {}
-
-// ❌ 避免拼音和無意義縮寫
-const yonghu = '用戶' // ❌
-const btn = <button /> // ❌
-const user = '用戶' // ✅
-const button = <button /> // ✅
-```
-
-### 代碼整潔度 🧹
-
-#### 必須移除
-- ❌ 所有 `console.log` / `console.error`（除非是刻意的錯誤日誌）
-- ❌ 註解的代碼（使用 git 管理版本，不要保留註解代碼）
-- ❌ 未處理的 `TODO` / `FIXME`（應轉為 Issue 或立即處理）
-- ❌ 未使用的 import
-- ❌ 未使用的變數和函數
-
-#### 代碼格式
-```typescript
-// ✅ 適當的空行增加可讀性
-function Component() {
-  const [state, setState] = useState(0)
-
-  const handleClick = () => {
-    setState(state + 1)
-  }
-
-  return (
-    <button onClick={handleClick}>
-      {state}
-    </button>
-  )
-}
-
-// ❌ 過於緊湊
-function Component(){const[state,setState]=useState(0);return<button>{state}</button>}
-```
-
-### 安全性檢查 🔒
-
-#### 環境變數管理
-```typescript
-// ✅ 使用環境變數
-const API_KEY = process.env.NEXT_PUBLIC_API_KEY
-const STRIPE_KEY = process.env.NEXT_PUBLIC_STRIPE_KEY
-
-// ✅ 伺服器端敏感變數不帶 NEXT_PUBLIC_ 前綴
-const SECRET_KEY = process.env.SECRET_KEY
-
-// ❌ 硬編碼密鑰
-const API_KEY = 'sk-1234567890abcdef' // ❌ 危險！
-```
-
-#### 輸入驗證
-```typescript
-// ✅ 驗證用戶輸入
-const handleSubmit = (input: string) => {
-  if (!input || input.trim().length === 0) {
-    toast('輸入不能為空')
-    return
-  }
-
-  if (input.length > 100) {
-    toast('輸入過長（最多 100 字元）')
-    return
-  }
-
-  sendToAPI(input)
-}
-
-// ✅ 限制輸入長度
-<input
-  type="text"
-  value={name}
-  maxLength={100}
-  onChange={e => setName(e.target.value)}
-/>
-```
-
-#### 安全檢查清單
-- [ ] 無硬編碼 API Key、Token、密碼
-- [ ] `.env` 文件在 `.gitignore` 中
-- [ ] 所有用戶輸入都經過驗證
-- [ ] 敏感日誌已移除或脫敏
-
-### 測試要求 🧪
-
-#### 測試覆蓋目標
-- 新組件必須有對應測試
-- 測試覆蓋率目標：> 70%
-- 測試應包含：正常情況、邊界情況、錯誤處理
-
-#### 組件測試範例
-```typescript
-import { render, screen, fireEvent } from '@testing-library/react'
-import { ProductCard } from './productCard'
-
-describe('ProductCard', () => {
-  it('should render product information', () => {
-    const product = { id: 1, name: 'Test', price: 100 }
-    render(<ProductCard product={product} />)
-
-    expect(screen.getByText('Test')).toBeInTheDocument()
-    expect(screen.getByText('$100')).toBeInTheDocument()
-  })
-
-  it('should handle click event', () => {
-    const handleClick = jest.fn()
-    render(<ProductCard onAddToCart={handleClick} />)
-
-    fireEvent.click(screen.getByText('Add to Cart'))
-    expect(handleClick).toHaveBeenCalled()
-  })
-})
-```
-
-### 提交前檢查清單 ✅
-
-在提交代碼前，請確認：
+若 repo 實際結構不同，先遵循現有模式，再更新這份文件。
+
+## 命名與放置
+
+| 項目 | 慣例 | 範例 |
+| --- | --- | --- |
+| 元件 symbol | `PascalCase` | `ProductCard` |
+| 元件檔案 | `camelCase` | `productCard.tsx` |
+| Custom hook | `useXxx` | `useInventoryList.ts` |
+| 事件 handler | `handleXxx` | `handleSubmit` |
+| Callback prop | `onXxx` | `onConfirm` |
+| 共用型別 | 放在 `types/`，用領域命名 | `inventoryList.ts` |
+
+- 先找是否已有可重用元件、hook、輔助函式或型別。
+- 跨功能可重用的 UI 才放到共用 `components/`。
+- 單一路由流程專用的 UI 可以留在該路由目錄。
+- 新增或移動元件時，依 Atomic Design 技能文件與既有分層慣例。
+
+## 常用指令
+
+在 repo 根目錄執行：
 
 ```bash
-# 1. 類型檢查通過
-npm run type-check
-
-# 2. Lint 檢查通過
-npm run lint
-
-# 3. 格式化檢查通過
-npm run format:check
-
-# 4. 測試通過
-npm test
+pnpm --filter frontend run dev
+pnpm --filter frontend run type-check
+pnpm --filter frontend run lint
+pnpm --filter frontend run build
+pnpm --filter frontend run format
 ```
 
-#### 代碼品質清單
-- [ ] 所有 TypeScript 類型正確
-- [ ] 無 ESLint 錯誤或警告
-- [ ] 代碼已格式化（Prettier）
-- [ ] 移除所有 console.log
-- [ ] 移除所有註解代碼
-- [ ] 無未處理的 TODO
-- [ ] 測試通過且覆蓋率足夠
-- [ ] 無硬編碼敏感資訊
-- [ ] 所有 import 都有使用
+`format` 會寫入檔案。只改文件時，使用符合風險的檢查即可。
 
-詳細規範請參考：@AI_CODE_REVIEW.md 第 6、7、8 章
+## 邊界決策
 
-## 狀態管理
+| 邊界 | 專案決策 |
+| --- | --- |
+| API/data boundary | UI 不散落原始 API shape；轉換集中在資料邊界。 |
+| 錯誤流程 | 同一個資料邊界不要混用回傳值錯誤與丟出例外。 |
+| 可預期錯誤 | 表單錯誤、查無資料、API 失敗等應回到 UI state、form state 或 toast。 |
+| 未預期錯誤 | 明確丟出或交給合適的 error boundary；不要用空 catch 吃掉。 |
+| Shared state | 狀態更新集中在 hook、狀態擁有者或明確 handler，不從任意元件直接 patch。 |
+| 使用者回饋 | Toast 是使用者回饋；`console.error()` 只能輔助診斷，不能替代 UI feedback。 |
+| i18n | 沒有 i18n 基礎建設前，不把 locale 更新列為強制規則。 |
 
-- 使用 React hooks（useState, useEffect 等）
-- 複雜狀態考慮使用 useReducer
+## 審查提醒，不是硬性失敗
 
-## 圖示系統
+| 提醒 | 審查動作 |
+| --- | --- |
+| `.tsx` component 超過 200 行 | 檢查是否混合資料、狀態與 UI 責任。 |
+| Props 超過 7 個 | 檢查資料結構、責任邊界或是否需要拆分 API。 |
+| 函式過長 | 檢查能否用 guard clause、命名清楚的 helper 或更直接的資料流簡化。 |
+| 巢狀太深 | 優先整理控制流，不把難懂邏輯壓成更難懂的一行。 |
 
-- 使用 lucide-react 作為圖示庫
-- 保持圖示風格一致
+拆分必須讓責任邊界更清楚，不能只是把複雜度藏到另一個檔案。
 
-## 注意事項
+## 交付前
 
-- 修改現有組件時，確保不破壞其他頁面的使用
-- 新增功能前先檢查是否有可重用的組件
-- 遵循 Git commit message 規範（參考現有 commit history）
+- 只改文件：檢查連結、過期引用、行數與 hook 提醒內容。
+- 前端 TS/TSX/設定檔：至少執行 `pnpm --filter frontend run type-check`，視風險加 lint 或 build。
+- 已暫存的前端 JS/TS/TSX：可用 `pnpm --filter frontend run lint-staged` 驗證即將提交的檔案。
+- 包含後端或 migration：依 `.claude/hooks/README.md` 使用對應檢查。
+- 檢查 diff 是否只解決本次問題，且沒有過期路徑、指令或不存在的檔案。


### PR DESCRIPTION
- Add .claude/rules frontend standards, template and README index
- Add .claude/hooks context reminder and pre-commit validation scripts
- Add .claude/skills/atomic-design-convention component convention
- Add .claude/commands/commit-message slash command
- Add .claude/settings.json to register UserPromptSubmit hook
- Add AGENTS.md project engineering principles
- Slim apps/frontend/CLAUDE.md to point at the new rule sources