### PR TITLE
docs(claude): align commit guide and rule scopes

### DIFF
--- a/.claude/commands/commit-message.md
+++ b/.claude/commands/commit-message.md
@@ -5,7 +5,9 @@ description: Generate Conventional Commits message based on staged changes (Chin
 
 ## Task
 
-Analyze staged Git changes and generate commit messages. Do **not** execute `git commit`, `git add`, or any other mutating command under any circumstances — only output the message for the user to copy.
+Analyze staged Git changes and generate commit messages. Do **not** execute
+`git commit`, `git add`, or any other mutating command under any
+circumstances. Only output the message for the user to copy.
 
 ## Git Status
 
@@ -15,13 +17,15 @@ Analyze staged Git changes and generate commit messages. Do **not** execute `git
 
 !git diff --cached
 
-## Unstaged Changes (for reference only — do not base commit message on these)
+## Unstaged Changes (for reference only - do not base commit message on these)
 
 !git diff
 
+---
+
 ## Commit Message Format
 
-Use Conventional Commits specification:
+Use the Conventional Commits specification:
 
 ```text
 <type>[(<scope>)][!]: <subject>
@@ -38,65 +42,97 @@ Use Conventional Commits specification:
 | `feat`     | New feature or API                           | MINOR  |
 | `fix`      | Bug fix or error handling                    | PATCH  |
 | `perf`     | Performance improvement (no behavior change) | PATCH  |
-| `refactor` | Code restructuring (not feat / fix)          | —      |
-| `style`    | Formatting, whitespace, linting              | —      |
-| `docs`     | Documentation or comments only               | —      |
-| `test`     | Adding or modifying tests                    | —      |
-| `build`    | Build system or dependency changes           | —      |
-| `ci`       | CI/CD configuration changes                  | —      |
-| `chore`    | Other maintenance not affecting src/test     | —      |
-| `revert`   | Reverting a previous commit                  | —      |
+| `refactor` | Code restructuring (not feat / fix)          | -      |
+| `style`    | Formatting, whitespace, linting              | -      |
+| `docs`     | Documentation or comments only               | -      |
+| `test`     | Adding or modifying tests                    | -      |
+| `build`    | Build system or dependency changes           | -      |
+| `ci`       | CI/CD configuration changes                  | -      |
+| `chore`    | Other maintenance not affecting src/test     | -      |
+| `revert`   | Reverting a previous commit                  | -      |
 
 ### Scope
 
-Infer from file paths or functional modules, e.g.: `auth`, `api`, `ui`, `components`, `utils`, `router`
+Infer the scope from file paths or functional modules, for example:
+`auth`, `api`, `ui`, `views`, `components`, `stores`, `router`, `survey`,
+`utils`, `docs`.
+
+Prefer the smallest meaningful scope. If one clear scope cannot be inferred,
+omit the scope instead of inventing one.
 
 ### Breaking Change
 
-Add `!` after type/scope; add `BREAKING CHANGE:` in footer:
+Add `!` after type/scope and add `BREAKING CHANGE:` in the footer:
 
 ```text
-feat(button)!: remove size prop, use class instead
+feat(button)!: remove size prop
 
-BREAKING CHANGE: `size` prop has been removed. Use Tailwind classes directly via `class` attribute.
+BREAKING CHANGE: `size` prop has been removed. Use CSS classes via `class`.
 ```
 
 ### Writing Guidelines
 
-- **Header** (`type(scope): subject`): ≤ 72 characters (ideally ≤ 50), no period at end
-- **subject**: Imperative mood — EN: lowercase start / ZH: 繁體中文，25 字以內
-- **body**: Explain **why**, not what. Bullet points for multi-item changes. Each line ≤ 72 characters
-- **footer**: Issue refs (`Closes #123`, `Refs #456`) or `BREAKING CHANGE:`
+- **Header** (`type(scope): subject`): <= 72 characters, ideally <= 50;
+  no period at the end
+- **subject**: imperative mood; EN starts lowercase; ZH uses Traditional
+  Chinese and stays within 25 characters when possible
+- **body**: one terse bullet per concern — state the outcome or reason
+  in ≤ 50 characters; omit detail that is obvious from the diff
+- Use bullet points for multi-item bodies; keep total bullets ≤ 5
+- Keep each body/footer line **<= 72 characters** — do not wrap;
+  shorten or split bullets instead
+- **footer**: issue refs (`Closes #123`, `Refs #456`) or
+  `BREAKING CHANGE:`
 
 ---
 
 ## Execution Steps
 
 1. **Check staged changes**
-   - If nothing staged → ask the user to stage the intended files first; do not proceed
-   - If changes exist but nothing staged → list the relevant unstaged paths and ask the user to stage them first; do not stage files yourself
+   - If nothing is staged, ask the user to stage the intended files first;
+     do not proceed to generate a commit message
+   - If there are unstaged changes but nothing staged, list the relevant
+     unstaged paths and ask the user to stage them first
+   - Never stage files yourself
 
 2. **Use this file as the source of truth**
-   - Follow the Conventional Commits rules below even if previous commits used a different format
+   - Follow these Conventional Commits rules even if previous commits used a
+     different format
+   - Do not rely on recent commit style if it conflicts with this file
 
-3. **Analyze staged diff** → determine type, infer scope, draft subject and body
+3. **Analyze staged diff**
+   - Determine the best type
+   - Infer the narrowest useful scope
+   - Draft a concise subject
+   - Add a body only when type + scope + subject do not convey full intent
+   - Omit body if the change is self-evident (e.g., `fix(btn): add disabled state`)
+   - Keep bullets ≤ 5; prefer fewer, shorter bullets over many detailed ones
 
-4. **Handle multiple unrelated changes** — if staged changes span unrelated concerns, output a concrete split plan **before** the commit messages:
-   ```
-   建議拆分為：
-   1. paths:
-      - apps/frontend/src/app/components/atoms/button/button.tsx
-      suggested message: feat(button): add loading state
+4. **Handle multiple unrelated changes**
+   - If staged changes span unrelated concerns, output a concrete split plan
+     **before** the commit messages
+   - The split plan must list paths and suggested messages only; do not
+     include `git add`, `git commit`, or other mutating commands
+   - Still output a combined message as a fallback
 
-   2. paths:
-      - apps/frontend/docs/button.md
-      suggested message: docs(button): document loading prop
-   ```
-   Then still output a combined message as fallback.
+```text
+建議拆分為：
+1. paths:
+   - src/services/surveyApi.ts
+   - src/types/survey.ts
+   suggested message: fix(api): handle survey submission errors
+
+2. paths:
+   - src/views/survey/SurveyEditor.vue
+   - src/components/survey/QuestionList.vue
+   suggested message: refactor(survey): simplify question editing flow
+```
 
 ---
 
 ## Output Format
+
+Output both versions directly. Do not ask for confirmation.
 
 📝 **繁體中文版本 (Traditional Chinese)**
 
@@ -118,6 +154,8 @@ BREAKING CHANGE: `size` prop has been removed. Use Tailwind classes directly via
 <footer>
 ```
 
+If no body or footer is needed, omit that section cleanly.
+
 ---
 
 ## Examples
@@ -127,11 +165,11 @@ BREAKING CHANGE: `size` prop has been removed. Use Tailwind classes directly via
 📝 **繁體中文版本**
 
 ```text
-feat(auth): 新增第三方 OAuth 登入功能
+feat(auth): 新增第三方 OAuth 登入
 
-- 實作 Google / GitHub OAuth 登入流程
-- 新增 token 刷新機制
-- 將登入狀態同步至 store
+- 支援 Google / GitHub OAuth 登入流程
+- 讓登入狀態能在重新整理後保留
+- 降低手動管理 token 的風險
 ```
 
 📝 **English Version**
@@ -139,36 +177,73 @@ feat(auth): 新增第三方 OAuth 登入功能
 ```text
 feat(auth): add third-party OAuth login
 
-- Implement Google / GitHub OAuth login flow
-- Add token refresh mechanism
-- Sync login state to store
+- Support Google / GitHub OAuth login flow
+- Preserve login state after page refresh
+- Reduce the risk of manual token handling
 ```
 
-### Mixed changes → split plan
+### Documentation-only commit
+
+📝 **繁體中文版本**
+
+```text
+docs(commands): 更新提交訊息指引
+
+- 收斂可執行的 Git 指令範圍
+- 明確要求只根據 staged diff 產生訊息
+```
+
+📝 **English Version**
+
+```text
+docs(commands): update commit message guide
+
+- Narrow the allowed Git command surface
+- Require messages to be based on staged diffs only
+```
+
+### Simple fix — no body needed
+
+📝 **繁體中文版本**
+
+```text
+fix(form): 修正 email 欄位送出前未驗證
+```
+
+📝 **English Version**
+
+```text
+fix(form): validate email before submission
+```
+
+### Mixed changes - split plan
 
 > ⚠️ Staged changes contain unrelated modifications. Suggested split:
 >
-> ```
+> ```text
 > 1. paths:
->    - apps/frontend/src/app/lib/api.ts
->    - apps/frontend/src/app/types/product.ts
->    suggested message: fix(api): handle product submission errors
+>    - src/services/surveyApi.ts
+>    - src/types/survey.ts
+>    suggested message: fix(api): handle survey submission errors
 >
 > 2. paths:
->    - apps/frontend/src/app/components/molecules/inventoryList/inventoryTableContent.tsx
->    - apps/frontend/src/app/components/atoms/button/button.tsx
->    suggested message: style(ui): adjust inventory table actions
+>    - docs/survey.md
+>    - .claude/commands/commit-message.md
+>    suggested message: docs(survey): update survey workflow docs
 > ```
 
-(Combined fallback message follows below)
+(Combined fallback message follows below.)
 
 ---
 
 ## Rules
 
-- Output both versions directly — do not ask for confirmation
-- **Never execute `git commit`** — only generate the message text
+- Output both Traditional Chinese and English versions
+- Do not ask for confirmation before outputting the messages
+- **Never execute `git commit`**
 - **Never execute mutating Git commands** such as `git add`, `git commit`, `git reset`, or `git checkout`
-- Ensure both versions carry consistent meaning
 - Accurately reflect staged changes only
+- Use unstaged changes only to explain why no message can be generated when nothing is staged
+- Ensure both language versions carry consistent meaning
 - If changes should be split, output the split plan **before** the commit messages
+- Avoid examples or assumptions from projects outside the current `.claude` context

--- a/.claude/rules/01-component-standards.md
+++ b/.claude/rules/01-component-standards.md
@@ -3,7 +3,6 @@ paths:
   [
     'apps/frontend/src/**/*.tsx',
     'apps/frontend/src/**/*.ts',
-    'apps/frontend/src/app/hooks/**/*.ts',
   ]
 ---
 

--- a/.claude/rules/02-code-quality.md
+++ b/.claude/rules/02-code-quality.md
@@ -3,9 +3,6 @@ paths:
   [
     'apps/frontend/src/**/*.tsx',
     'apps/frontend/src/**/*.ts',
-    'apps/frontend/src/app/hooks/**/*.ts',
-    'apps/frontend/src/app/lib/**/*.ts',
-    'apps/frontend/src/app/types/**/*.ts',
     'apps/backend/**/*.go',
     'apps/backend/internal/storage/sql/migration/scripts/**/*.sql',
   ]

--- a/.claude/rules/03-frontend-performance.md
+++ b/.claude/rules/03-frontend-performance.md
@@ -1,5 +1,11 @@
 ---
-paths: ['**/*.tsx', '**/*.ts', '**/next.config.ts', '**/package.json']
+paths:
+  [
+    'apps/frontend/src/**/*.tsx',
+    'apps/frontend/src/**/*.ts',
+    'apps/frontend/next.config.ts',
+    'apps/frontend/package.json',
+  ]
 ---
 
 # 前端效能 / Frontend Performance (準則 14-20)

--- a/.claude/rules/04-frontend-security.md
+++ b/.claude/rules/04-frontend-security.md
@@ -313,6 +313,11 @@ if (!isProfileInput(parsed)) {
 
 Do not put secrets, passwords, API keys, refresh tokens, or non-public data in the client bundle, browser-readable storage, URLs, logs, or mock data. `NEXT_PUBLIC_*` variables are shipped to the browser and must be treated as public. Auth tokens should be set by the backend as `HttpOnly; Secure; SameSite` cookies, and the frontend should access secret-backed services through same-origin APIs or controlled proxies.
 
+> **現狀（2026-Q2）**：後端 Swagger 在 `securityDefinitions` 已宣告 `BearerAuth`，但目前所有 operation **皆未套用 `security:` requirement**（見 `apps/backend/docs/swagger.yaml`），spec 上所有 endpoint 不需驗證。在 auth 流程與後端 security requirement 完整套用前：
+>
+> - 前端不要在個別 API function 自行加 `Authorization` header；auth 策略未定，集中放在共用 `apiRequest` wrapper，個別 hook 不處理 token。
+> - 一旦後端套用 security requirement 或前端引入 auth 流程，請更新或移除本註記。
+
 ### 為什麼重要 / Why This Matters
 
 - **XSS 放大效應**：`localStorage` 和 `sessionStorage` 可被成功執行的前端腳本讀取。

--- a/.claude/rules/05-state-error-handling.md
+++ b/.claude/rules/05-state-error-handling.md
@@ -3,8 +3,6 @@ paths:
   [
     'apps/frontend/src/**/*.tsx',
     'apps/frontend/src/**/*.ts',
-    'apps/frontend/package.json',
-    'apps/frontend/next.config.ts',
   ]
 ---
 
@@ -341,15 +339,63 @@ function ContactForm() {
 
 **推薦 ✅ - 集中轉換 API error code，不硬綁不存在的語系目錄**:
 
+> **後端錯誤契約現況**：現行後端 validation error 走 HTTP **400 + `body.error.code === 'VALIDATION_ERROR'` + `body.error.fields[]`**，**沒有**使用 Unprocessable Entity（見 `apps/backend/docs/swagger.yaml` 中 `dto.ErrorResponse` 與各 operation responses）。前端 validation branch 不要靠獨立 HTTP status 判斷；先從 `ApiError.payload` narrow 出 `dto.ErrorResponse`，再以 `body.error.code` 為主、HTTP status 為輔。
+
+```typescript
+interface ApiErrorResponse {
+  success: false
+  error: {
+    code: string
+    message: string
+    fields?: Array<{ field: string; message: string }>
+    failed_ids?: string[]
+  }
+}
+
+function isApiErrorResponse(payload: unknown): payload is ApiErrorResponse {
+  if (typeof payload !== 'object' || payload === null || !('error' in payload)) {
+    return false
+  }
+
+  const body = payload as { success?: unknown; error?: unknown }
+  if (body.success !== false) {
+    return false
+  }
+
+  const error = body.error
+  if (typeof error !== 'object' || error === null) {
+    return false
+  }
+
+  const detail = error as { code?: unknown; message?: unknown }
+  return typeof detail.code === 'string' && typeof detail.message === 'string'
+}
+
+if (error instanceof ApiError) {
+  if (error.status === 401) {
+    // 未登入流程
+  } else if (isApiErrorResponse(error.payload)) {
+    const body = error.payload
+    if (body.error.code === 'VALIDATION_ERROR') {
+      // 取 body.error.fields 顯示欄位級錯誤
+    } else {
+      toast.error(getUserMessageFromApiErrorCode(body.error.code))
+    }
+  } else {
+    toast.error('操作失敗，請稍後再試')
+  }
+}
+```
+
 ```typescript
 const ERROR_MESSAGE_BY_CODE: Record<string, string> = {
-  VALIDATION_FAILED: '資料格式不正確，請檢查後再送出',
+  VALIDATION_ERROR: '資料格式不正確，請檢查後再送出',
   PERMISSION_DENIED: '您沒有權限執行此操作',
   RATE_LIMITED: '操作太頻繁，請稍後再試',
 }
 
-export function getUserMessageFromApiError(error: ApiError): string {
-  return ERROR_MESSAGE_BY_CODE[error.code] ?? '操作失敗，請稍後再試'
+export function getUserMessageFromApiErrorCode(code: string): string {
+  return ERROR_MESSAGE_BY_CODE[code] ?? '操作失敗，請稍後再試'
 }
 ```
 

--- a/.claude/rules/06-collaboration.md
+++ b/.claude/rules/06-collaboration.md
@@ -1,5 +1,10 @@
 ---
-paths: ['**/*.md', 'apps/frontend/src/**/*.ts', 'apps/frontend/src/**/*.tsx']
+paths:
+  [
+    'apps/frontend/src/**/*.ts',
+    'apps/frontend/src/**/*.tsx',
+    'apps/frontend/**/*.md',
+  ]
 ---
 
 # 協作與溝通 / Collaboration & Communication (準則 29-31)
@@ -63,6 +68,8 @@ console.log(user.created_at.toLocaleDateString())
 
 問題是呼叫端不知道 `created_at` 是字串、`Date`、`null`，也不知道失敗時 response 長什麼樣子。
 
+> **後端 schema 命名約定**：本專案後端 Swagger schema 以 `dto.XxxRequest` / `dto.XxxResponse` 命名（Go 套件前綴，見 `apps/backend/docs/swagger.yaml`），欄位一律 snake_case。前端 adapter 把 `dto.` namespace 移除（如 `dto.CategoryResponse` → `CategoryResponse`），欄位轉 camelCase；`*Response` 型別僅用於 adapter 邊界，不外流到 component。
+
 **推薦 - 在 API adapter 定義契約與轉換**:
 
 ```typescript
@@ -104,10 +111,15 @@ export async function getUser(id: string): Promise<User> {
 **推薦 - 明確表示 API 錯誤格式**:
 
 ```typescript
+// 對應後端 dto.ErrorResponse（見 apps/backend/docs/swagger.yaml）
 interface ApiErrorResponse {
-  code: string
-  message: string
-  fieldErrors?: Record<string, string[]>
+  success: false
+  error: {
+    code: string                                          // 如 'VALIDATION_ERROR'、'PRODUCT_NOT_FOUND'
+    message: string
+    fields?: Array<{ field: string; message: string }>    // 對應 dto.ValidationFieldError
+    failed_ids?: string[]                                 // batch 操作部分失敗時回傳
+  }
 }
 
 export class ApiError extends Error {
@@ -115,10 +127,16 @@ export class ApiError extends Error {
     readonly status: number,
     readonly body: ApiErrorResponse
   ) {
-    super(body.message)
+    super(body.error.message)
   }
 }
 ```
+
+`body.error.fields` 是 validation error 用、`body.error.failed_ids` 是 batch 操作（如 `DELETE /products/batch-delete`）部分失敗用；兩者不會同時出現。錯誤分流請以 `body.error.code` 為主、HTTP status 為輔，詳見 [05-state-error-handling.md](05-state-error-handling.md) 準則 27。
+
+**推薦 - multipart endpoint 不要手動設 Content-Type**:
+
+後端目前只有 `POST /upload` 使用 `multipart/form-data`（欄位 `files`，多檔上傳）。這類 endpoint 在 adapter 直接把 `FormData` 傳給 `fetch` 的 `body`，**不要自行設 `Content-Type` header**，要讓瀏覽器補上正確的 multipart boundary。
 
 ### 常見陷阱 / Common Pitfalls
 


### PR DESCRIPTION
- Tighten commit-message command format and examples
- Narrow rule paths to actual frontend scope
- Note current backend Bearer auth and dto.* naming
- Update VALIDATION_ERROR contract and error branching
- Clarify multipart upload must not set Content-Type